### PR TITLE
Add build files for gcode_parser

### DIFF
--- a/src/Gcode_parser/CMakeLists.txt
+++ b/src/Gcode_parser/CMakeLists.txt
@@ -1,0 +1,38 @@
+cmake_minimum_required(VERSION 3.5)
+project(gcode_parser)
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(nav_msgs REQUIRED)
+find_package(geometry_msgs REQUIRED)
+
+add_executable(gcode_reader_node
+  Src/gcode_reader_node.cpp
+  Src/gcode_parser.cpp
+)
+
+target_include_directories(gcode_reader_node PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Include>
+  $<INSTALL_INTERFACE:include>
+)
+
+ament_target_dependencies(gcode_reader_node
+  rclcpp
+  nav_msgs
+  geometry_msgs
+)
+
+install(TARGETS gcode_reader_node
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+install(DIRECTORY Include/
+  DESTINATION include
+)
+
+ament_package()

--- a/src/Gcode_parser/package.xml
+++ b/src/Gcode_parser/package.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>gcode_parser</name>
+  <version>0.1.0</version>
+  <description>G-code parser library and reader node.</description>
+  <maintainer email="KylerLaird@todo.com">Kyler Laird</maintainer>
+  <license>GPLv3</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>nav_msgs</depend>
+  <depend>geometry_msgs</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
## Summary
- make gcode_parser a proper ROS 2 package
- add package.xml with dependencies
- add CMakeLists.txt for gcode_reader_node executable

## Testing
- `colcon build --packages-select gcode_parser` *(fails: colcon not found)*