### PR TITLE
Fix ROS2 setup in CI

### DIFF
--- a/.github/workflows/ros2-ci.yml
+++ b/.github/workflows/ros2-ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup ROS 2
         uses: ros-tooling/setup-ros@v0.2
         with:
-          distribution: humble
+          required-ros-distributions: humble
 
       # 3. Install OS-level build tools
       - name: Install OS dependencies


### PR DESCRIPTION
## Summary
- correct ROS distribution input for setup-ros action

## Testing
- `pytest -q`