### PR TITLE
Add Arduino board READMEs

### DIFF
--- a/Arduino-JD6330/README.md
+++ b/Arduino-JD6330/README.md
@@ -1,0 +1,41 @@
+# John Deere 6330 Arduino
+
+This directory contains the sketch used on an Arduino board for controlling the JD6330 tractor. It communicates with ROS over `rosserial`.
+
+## Requirements
+
+* Arduino IDE 1.8 or newer (or `arduino-cli` >= 0.33)
+* Board: **Arduino/Genuino Uno** (`arduino:avr:uno`)
+
+## Building with `arduino-cli`
+
+```bash
+arduino-cli compile --fqbn arduino:avr:uno Arduino-JD6330.ino
+```
+
+## Uploading
+
+Connect the board (usually `/dev/ttyACM0`) and run:
+
+```bash
+arduino-cli upload -p /dev/ttyACM0 --fqbn arduino:avr:uno Arduino-JD6330.ino
+```
+
+Once uploaded, bring up the ROS serial bridge:
+
+```bash
+rosrun rosserial_python serial_node.py /dev/ttyACM0 _baud:=57600
+```
+
+## ROS Topics
+
+This microcontroller subscribes to the following command topics:
+
+* `/steering/put` – desired steering angle (`std_msgs/UInt8`)
+* `/transmission/shuttle/put` – shuttle control (`std_msgs/UInt8`)
+* `/throttle/put` – throttle command (`std_msgs/UInt8`)
+* `/hitch/put` – 3‑pt hitch position (`std_msgs/UInt8`)
+* `/ignition/put` – ignition enable (`std_msgs/Bool`)
+* `/passthrough/put` – manual/auto switch (`std_msgs/Bool`)
+
+The board publishes status on matching `/get` topics such as `/steering/get` and `/throttle/get`.

--- a/Arduino-MT765/README.md
+++ b/Arduino-MT765/README.md
@@ -1,0 +1,31 @@
+# Challenger MT765 Arduino
+
+This sketch runs on an Arduino Uno for the MT765 control box. It listens for ROS commands via `rosserial` and sets PWM outputs for throttle, transmission and steering.
+
+## Requirements
+
+* Arduino IDE 1.8+ or `arduino-cli` >= 0.33
+* Board: **Arduino/Genuino Uno** (`arduino:avr:uno`)
+
+## Compile and Upload
+
+```bash
+arduino-cli compile --fqbn arduino:avr:uno Arduino-MT765.ino
+arduino-cli upload -p /dev/ttyACM0 --fqbn arduino:avr:uno Arduino-MT765.ino
+```
+
+After uploading, start the serial bridge:
+
+```bash
+rosrun rosserial_python serial_node.py /dev/ttyACM0 _baud:=57600
+```
+
+## ROS Topics
+
+The firmware subscribes to these topics for command input:
+
+* `/throttle/put` – throttle setting (`std_msgs/UInt8`)
+* `/transmission/put` – forward/neutral/reverse (`std_msgs/UInt8`)
+* `/steering/put` – steering angle (`std_msgs/UInt8`)
+
+It drives the actuators directly without publishing feedback topics.


### PR DESCRIPTION
## Summary
- document setup for the JD6330 Arduino
- add MT765 Arduino instructions

## Testing
- `colcon test` *(fails: command not found)*