### PR TITLE
Update docs license

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,4 +197,4 @@ A CI workflow (`.github/workflows/ros2-ci.yml`) now also builds & lint‑tests:
 
 ## 📝 License
 
-**GPL v3**. See [LICENSE](LICENSE).
+This project is released under the **Autonomous Tractor Software License (ATSL) 1.0**. See [LICENSE](LICENSE) for details.

--- a/README_AUTONOMY_PLAN.md
+++ b/README_AUTONOMY_PLAN.md
@@ -135,4 +135,4 @@ This README outlines a complete plan to evolve Tractobots into a **fully autonom
 
 This is an open roadmap. If you’re building autonomous systems or ISOBUS tools for farming, we’d love your feedback or help extending this framework. Fork and PR welcome!
 
-Licensed under **GPL v3**. Built with care by **Crop Crusaders**.
+Licensed under the **Autonomous Tractor Software License (ATSL) 1.0**. Built with care by **Crop Crusaders**.


### PR DESCRIPTION
## Notes
- Updated README docs to reference the Autonomous Tractor Software License (ATSL) 1.0 as specified in LICENSE

## Testing
- `pytest`
