### PR TITLE
Document MIT license for iso_bus_watchdog

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,3 +198,6 @@ A CI workflow (`.github/workflows/ros2-ci.yml`) now also builds & lint‑tests:
 ## 📝 License
 
 This project is released under the **Autonomous Tractor Software License (ATSL) 1.0**. See [LICENSE](LICENSE) for details.
+
+`iso_bus_watchdog` is an exception and continues to be distributed under the MIT
+license in order to remain compatible with the upstream AgIsoStack++ project.


### PR DESCRIPTION
## Summary
- note that `iso_bus_watchdog` uses the MIT License

## Testing
- `grep -n MIT -n README.md`