### PR TITLE
Update CI workflow with new ROS key and README note

### DIFF
--- a/.github/workflows/ros2-ci.yml
+++ b/.github/workflows/ros2-ci.yml
@@ -16,7 +16,7 @@ jobs:
 
       # 2. Install ROS 2 (Humble)
       - name: Setup ROS 2
-        uses: ros-tooling/setup-ros@v0.2
+        uses: ros-tooling/setup-ros@v0.7.12
         with:
           required-ros-distributions: humble
 

--- a/README.md
+++ b/README.md
@@ -191,8 +191,18 @@ Published topics:
 
 A CI workflow (`.github/workflows/ros2-ci.yml`) now also builds & lint‑tests:
 
-- `iso_bus_watchdog` alongside the other packages  
+- `iso_bus_watchdog` alongside the other packages
 - SocketCAN integration checks on Ubuntu 22.04 & Humble
+- Uses `ros-tooling/setup-ros@v0.7.12` so `apt-get update` works with the current ROS key
+
+Example step:
+
+```yaml
+- name: Setup ROS 2
+  uses: ros-tooling/setup-ros@v0.7.12
+  with:
+    required-ros-distributions: humble
+```
 
 ---
 


### PR DESCRIPTION
## Summary
- use `ros-tooling/setup-ros@v0.7.12` in CI workflow so the new ROS GPG key is used
- document the new action version in README with example snippet

## Testing
- `colcon test` *(fails: `colcon: command not found`)*