### PR TITLE
Fix ROS setup action

### DIFF
--- a/.github/workflows/ros2-ci.yml
+++ b/.github/workflows/ros2-ci.yml
@@ -16,15 +16,18 @@ jobs:
 
       # 2. Install ROS 2 (Humble)
       - name: Setup ROS 2
-        uses: ros-tooling/setup-ros@v0.7.12
-        with:
-          required-ros-distributions: humble
+        run: |
+          sudo apt update && sudo apt install -y curl gnupg2 lsb-release software-properties-common
+          sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/ros2.list
+          sudo apt update
+          sudo apt install -y ros-humble-desktop python3-colcon-common-extensions python3-rosdep2 python3-pip
 
       # 3. Install OS-level build tools
       - name: Install OS dependencies
         run: |
           sudo apt update
-          sudo apt install -y python3-colcon-common-extensions python3-pip python3-pytest
+          sudo apt install -y python3-pytest
 
       # 4. Install ROS 2 package dependencies
       - name: rosdep install


### PR DESCRIPTION
## Summary
- replace unavailable `ros-tooling/setup-ros` action with inline commands
- simplify OS dependency installation

## Testing
- `pytest -q`