### PR TITLE
Fix GitHub Actions ROS2 CI runner

### DIFF
--- a/.github/workflows/ros2-ci.yml
+++ b/.github/workflows/ros2-ci.yml
@@ -7,7 +7,9 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
+    # ROS 2 Humble packages are only available for Ubuntu 22.04 (Jammy)
+    # Use the jammy runner so apt can install ros-humble-desktop
+    runs-on: ubuntu-22.04
     steps:
 
       # 1. Check out repository

--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ A CI workflow (`.github/workflows/ros2-ci.yml`) now also builds & lint‑tests:
 
 - `iso_bus_watchdog` alongside the other packages
 - SocketCAN integration checks on Ubuntu 22.04 & Humble
+- CI runner explicitly uses `ubuntu-22.04` so ROS 2 packages install correctly
 - Uses `ros-tooling/setup-ros@v0.7.12` so `apt-get update` works with the current ROS key
 
 Example step:


### PR DESCRIPTION
## Summary
- use Ubuntu 22.04 runner for ROS2 CI
- document the runner requirement in README

## Testing
- `colcon test --event-handlers console_direct+` *(fails: colcon not found)*