### PR TITLE
Add Tkinter Mission Control GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Field robots for precision agriculture — now super‑powered on **ROS 2 (Humb
 - **MapViz integration**: Offline Google Maps + live pose/TF visualization  
 - **Row-by-Row Guidance**: Precise A–B line following for autonomous pass‑by‑pass tractor operation  
 - **ISOBUS Watchdog Node**: New C++ node using AgIsoStack++ to monitor engine oil pressure, fuel pressure, coolant temp, and fuel level with auto cut‑out and emergency‑stop  
- - **Mission Control UI**: Web page to start/stop missions and trigger an emergency stop
+ - **Mission Control UI**: Web page or Tkinter GUI to start/stop missions and trigger an emergency stop
 
 ---
 
@@ -181,6 +181,17 @@ Published topics:
 1. **Record A–B line**: In your driver, hold Nav + Y to start “north” line at current GPS.  
 2. **Follow**: The Line Follower algorithm computes cross‑track error and steers accordingly.  
 3. **Repeat**: At end‑of‑row, manually switch row or extend logic for auto headland turns.
+
+### 7. Mission Control UI
+
+A small Tkinter window can start or stop missions and toggle the emergency stop.
+
+```bash
+ros2 run tractobots_mission_ui mission_gui_node
+```
+
+The original web interface is still available on port 8088 when running
+`mission_ui_node`.
 
 ---
 

--- a/README_AUTONOMY_PLAN.md
+++ b/README_AUTONOMY_PLAN.md
@@ -113,7 +113,7 @@ This README outlines a complete plan to evolve Tractobots into a **fully autonom
 | `isobus_steering_node` | Sends ISOBUS messages to control steering    |
 | `tool_control_node`    | Toggles implement tools from Z commands      |
 | `field_logger_node`    | Records geotagged actions and tool state     |
-| `mission_ui_node`      | GUI/Web UI to control missions & display logs|
+| `mission_ui_node` / `mission_gui_node` | Web or Tk GUI to control missions & display logs|
 
 ---
 

--- a/src/tractobots_mission_ui/package.xml
+++ b/src/tractobots_mission_ui/package.xml
@@ -1,7 +1,7 @@
 <package format="3">
   <name>tractobots_mission_ui</name>
   <version>0.0.1</version>
-  <description>Simple web-based mission control interface for Tractobots</description>
+  <description>Simple web-based and Tkinter mission control interface for Tractobots</description>
 
   <maintainer email="KylerLaird@todo.com">Kyler Laird</maintainer>
   <license>GPLv3</license>

--- a/src/tractobots_mission_ui/setup.py
+++ b/src/tractobots_mission_ui/setup.py
@@ -15,11 +15,12 @@ setup(
     zip_safe=True,
     maintainer='Kyler Laird',
     maintainer_email='KylerLaird@todo.com',
-    description='Web interface to start/stop missions',
+    description='Web and GUI interface to start/stop missions',
     license='GPLv3',
     entry_points={
         'console_scripts': [
             'mission_ui_node = tractobots_mission_ui.mission_ui_node:main',
+            'mission_gui_node = tractobots_mission_ui.mission_gui_node:main',
         ],
     },
 )

--- a/src/tractobots_mission_ui/tractobots_mission_ui/__init__.py
+++ b/src/tractobots_mission_ui/tractobots_mission_ui/__init__.py
@@ -1,0 +1,1 @@
+"""Tractobots mission control UI package."""

--- a/src/tractobots_mission_ui/tractobots_mission_ui/mission_gui_node.py
+++ b/src/tractobots_mission_ui/tractobots_mission_ui/mission_gui_node.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Tkinter-based Mission Control GUI node.
+
+Provides a small window with buttons to start or stop a mission and to
+trigger or reset the emergency stop. ROS 2 spinning happens in a
+background thread so the GUI remains responsive.
+"""
+
+import threading
+import tkinter as tk
+
+import rclpy
+from rclpy.node import Node
+from std_msgs.msg import Bool
+
+
+class MissionGuiNode(Node):
+    def __init__(self):
+        super().__init__('mission_gui_node')
+
+        self.mission_pub = self.create_publisher(Bool, '/mission/start', 1)
+        self.emergency_pub = self.create_publisher(Bool, '/emergency_stop', 1)
+
+    def start_mission(self):
+        self.mission_pub.publish(Bool(data=True))
+        self.get_logger().info('Mission start requested via GUI')
+
+    def stop_mission(self):
+        self.mission_pub.publish(Bool(data=False))
+        self.get_logger().info('Mission stop requested via GUI')
+
+    def trigger_estop(self):
+        self.emergency_pub.publish(Bool(data=True))
+        self.get_logger().warn('Emergency stop triggered via GUI')
+
+    def reset_estop(self):
+        self.emergency_pub.publish(Bool(data=False))
+        self.get_logger().info('Emergency stop cleared via GUI')
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = MissionGuiNode()
+
+    # Spin node in background so Tkinter remains responsive
+    spin_thread = threading.Thread(target=rclpy.spin, args=(node,), daemon=True)
+    spin_thread.start()
+
+    root = tk.Tk()
+    root.title('Mission Control')
+
+    tk.Button(root, text='Start Mission', command=node.start_mission).pack(fill='x')
+    tk.Button(root, text='Stop Mission', command=node.stop_mission).pack(fill='x')
+    tk.Button(root, text='Emergency Stop', command=node.trigger_estop).pack(fill='x')
+    tk.Button(root, text='Reset E-Stop', command=node.reset_estop).pack(fill='x')
+
+    try:
+        root.mainloop()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add Tkinter-based mission_gui_node for mission control
- update setup and package descriptions
- document mission GUI in READMEs

## Testing
- `pytest -q`