### PR TITLE
Add Codex guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,12 @@ Example step:
     required-ros-distributions: humble
 ```
 
+## 🤖 Codex Quickstart
+
+For a short overview of how to build and test Tractobots in automated setups,
+see [docs/CODEX_GUIDE.md](docs/CODEX_GUIDE.md). It lists the basic steps to
+install ROS 2, build the workspace with `colcon`, and run unit tests.
+
 ---
 
 ## 📝 License

--- a/docs/CODEX_GUIDE.md
+++ b/docs/CODEX_GUIDE.md
@@ -1,0 +1,60 @@
+# Codex Guide for Tractobots
+
+This short guide explains how Codex or any automated tooling can set up and run
+the Tractobots code base for analysis or testing purposes.
+
+## 1. System Dependencies
+
+Tractobots targets **Ubuntu 22.04** with ROS 2 Humble. The easiest way to set
+up all required packages is to run the helper script in the repository root:
+
+```bash
+./install_ros2_humble.sh
+```
+
+It installs ROS 2, Python build tools, and initializes `rosdep`. Make sure to
+`source /opt/ros/humble/setup.bash` after installation.
+
+## 2. Building the Workspace
+
+Clone the repository inside a ROS 2 workspace and build with `colcon`:
+
+```bash
+mkdir -p ~/ros2_tractobots/src
+cd ~/ros2_tractobots/src
+git clone <this repo>
+cd ..
+colcon build --symlink-install
+source install/setup.bash
+```
+
+## 3. Launching the Stack
+
+Common launch files live in `src/tractobots_launchers/launch`. To bring up the
+sensors and state estimation stack, run:
+
+```bash
+ros2 launch tractobots_launchers bringup.launch.py
+```
+
+Additional launch files exist for MapViz and pose transforms.
+
+## 4. Running Tests
+
+Some packages include unit tests using `pytest` or `ament_cmake`. After
+building the workspace, tests can be executed with:
+
+```bash
+colcon test
+colcon test-result --all
+```
+
+## 5. Where to Look
+
+- Core launch files: `src/tractobots_launchers/launch`
+- Navigation driver: `src/tractobots_navigation/tractobots_navigation/driver.py`
+- G-code parser: `src/Gcode_parser`
+- Robot description: `src/tractobots_description/urdf`
+
+These locations provide a starting point when inspecting how the code works.
+


### PR DESCRIPTION
## Summary
- add a short guide for how Codex or CI can set up and run the code base
- reference the new guide from the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a1ad9968883218d49cfb83c335c53