### PR TITLE
Fix ament packages

### DIFF
--- a/.github/workflows/ros2-ci.yml
+++ b/.github/workflows/ros2-ci.yml
@@ -25,6 +25,12 @@ jobs:
           sudo apt update
           sudo apt install -y ros-humble-desktop python3-colcon-common-extensions python3-rosdep2 python3-pip
 
+      - name: Install ROS 2 base
+        run: |
+          sudo apt update
+          sudo apt install ros-humble-ros-base -y
+          source /opt/ros/humble/setup.bash
+
       # 3. Install OS-level build tools
       - name: Install OS dependencies
         run: |

--- a/src/Advancednavigation/CMakeLists.txt
+++ b/src/Advancednavigation/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.5)
-project(ros2-driver)
+cmake_minimum_required(VERSION 3.22)
+project(ros2-driver LANGUAGES CXX C)
 
 # Default to C99
 if(NOT CMAKE_C_STANDARD)

--- a/src/AgIsoStackPlusPlus/CMakeLists.txt
+++ b/src/AgIsoStackPlusPlus/CMakeLists.txt
@@ -1,5 +1,7 @@
-cmake_minimum_required(VERSION 3.10)
-project(AgIsoStackPlusPlus)
+cmake_minimum_required(VERSION 3.22)
+project(AgIsoStackPlusPlus LANGUAGES CXX C)
+
+find_package(ament_cmake REQUIRED)
 
 add_library(isobus
   src/Isobus/isobus/can_message.cpp
@@ -13,16 +15,21 @@ add_library(isobus
 # Public headers
 target_include_directories(isobus PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
 )
 
 target_link_libraries(isobus PUBLIC pthread)
 
 install(TARGETS isobus
-  EXPORT isobus-export
+  EXPORT export_isobus
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
 )
 
 install(DIRECTORY include/ DESTINATION include)
 
+ament_export_include_directories(include)
+ament_export_libraries(isobus)
+ament_export_targets(export_isobus HAS_LIBRARY_TARGET)
 
+ament_package()

--- a/src/AgIsoStackPlusPlus/package.xml
+++ b/src/AgIsoStackPlusPlus/package.xml
@@ -1,16 +1,12 @@
 <?xml version="1.0"?>
 <package format="3">
-  <name>iso_bus_watchdog</name>
+  <name>AgIsoStackPlusPlus</name>
   <version>0.1.0</version>
-  <description>ISOBUS Watchdog Node using AgIsoStack++</description>
+  <description>Vendor library wrapper for AgIsoStack++</description>
   <maintainer email="you@example.com">Your Name</maintainer>
   <license>MIT</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-
-  <depend>rclcpp</depend>
-  <depend>std_msgs</depend>
-  <depend>AgIsoStackPlusPlus</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/src/Iso_bus_watchdog/CMakeLists.txt
+++ b/src/Iso_bus_watchdog/CMakeLists.txt
@@ -1,12 +1,12 @@
-cmake_minimum_required(VERSION 3.16)
-project(iso_bus_watchdog)
+cmake_minimum_required(VERSION 3.22)
+project(iso_bus_watchdog LANGUAGES CXX)
 
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(Threads REQUIRED)
+find_package(AgIsoStackPlusPlus REQUIRED)
 
-add_subdirectory(../AgIsoStackPlusPlus ${CMAKE_CURRENT_BINARY_DIR}/AgIsoStackPlusPlus)
 
 add_executable(iso_bus_watchdog_node
   src/iso_bus_watchdog_node.cpp
@@ -26,6 +26,8 @@ target_link_libraries(iso_bus_watchdog_node
 install(TARGETS iso_bus_watchdog_node
   DESTINATION lib/${PROJECT_NAME}
 )
+
+install(DIRECTORY include/ DESTINATION include)
 
 install(
   DIRECTORY launch

--- a/src/tractobots_description/CMakeLists.txt
+++ b/src/tractobots_description/CMakeLists.txt
@@ -1,3 +1,9 @@
-cmake_minimum_required(VERSION 2.8.3)
-project(tractobots_description)
-find_package(catkin REQUIRED COMPONENTS)
+cmake_minimum_required(VERSION 3.22)
+project(tractobots_description LANGUAGES CXX)
+
+find_package(ament_cmake REQUIRED)
+
+install(DIRECTORY urdf meshes launch rviz
+  DESTINATION share/${PROJECT_NAME})
+
+ament_package()

--- a/src/tractobots_description/package.xml
+++ b/src/tractobots_description/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="3">
   <name>tractobots_description</name>
   <version>0.0.1</version>
   <description>
@@ -13,5 +13,9 @@
   <url type="repository">https://github.com/cropcrusaders/tractobots.git</url>
   <license>GPLv3</license>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
 </package>


### PR DESCRIPTION
## Summary
- add missing AgIsoStackPlusPlus package
- clean up CMake for ros2-driver, iso_bus_watchdog, tractobots_description
- install headers/meshes/launch files
- tweak GitHub Actions to install ROS 2 base

## Testing
- `sudo apt update` *(fails: Could not connect to proxy)*
- `colcon build --symlink-install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a32b44df083218749d55c78edf19d