### PR TITLE
Fix ament_cmake discovery in CI

### DIFF
--- a/.github/workflows/ros2-ci.yml
+++ b/.github/workflows/ros2-ci.yml
@@ -44,12 +44,21 @@ jobs:
           rosdep update
           rosdep install --from-paths src --ignore-src -r -y
 
-      # 5. Build the workspace
+      # 5. Prepare build environment
+      - name: Install ros-base and setup
+        run: |
+          sudo apt update
+          sudo apt install -y ros-humble-ros-base
+          echo "source /opt/ros/humble/setup.bash" >> $GITHUB_ENV
+          # ★ Codex-edit
+
+      # 6. Build the workspace
       - name: Colcon build
         run: |
+          source /opt/ros/humble/setup.bash
           colcon build --symlink-install
-
-      # 6. Run tests and report results
+          # ★ Codex-edit
+      # 7. Run tests and report results
       - name: Colcon test
         run: |
           colcon test --event-handlers console_direct+

--- a/src/Advancednavigation/CMakeLists.txt
+++ b/src/Advancednavigation/CMakeLists.txt
@@ -15,7 +15,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-find_package(ament_cmake REQUIRED)
+find_package(ament_cmake REQUIRED) # ★ Codex-edit
 find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)

--- a/src/Advancednavigation/package.xml
+++ b/src/Advancednavigation/package.xml
@@ -7,7 +7,7 @@
   <maintainer email="support@advancednavigation.com">Support</maintainer>
   <license>MIT</license>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend> <!-- ★ Codex-edit -->
   <depend>rclcpp</depend>
   <depend>std_msgs</depend>
   <depend>sensor_msgs</depend>

--- a/src/AgIsoStackPlusPlus/CMakeLists.txt
+++ b/src/AgIsoStackPlusPlus/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.22)
+set(CMAKE_WARN_DEPRECATED FALSE) # ★ Codex-edit
 project(AgIsoStackPlusPlus LANGUAGES CXX C)
 
 find_package(ament_cmake REQUIRED)

--- a/src/AgIsoStackPlusPlus/package.xml
+++ b/src/AgIsoStackPlusPlus/package.xml
@@ -6,7 +6,7 @@
   <maintainer email="you@example.com">Your Name</maintainer>
   <license>MIT</license>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend> <!-- ★ Codex-edit -->
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/src/Iso_bus_watchdog/package.xml
+++ b/src/Iso_bus_watchdog/package.xml
@@ -6,7 +6,7 @@
   <maintainer email="you@example.com">Your Name</maintainer>
   <license>MIT</license>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend> <!-- ★ Codex-edit -->
 
   <depend>rclcpp</depend>
   <depend>std_msgs</depend>

--- a/src/tractobots_description/CMakeLists.txt
+++ b/src/tractobots_description/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.22)
 project(tractobots_description LANGUAGES CXX)
 
 find_package(ament_cmake REQUIRED)
+ # ★ Codex-edit
 
 install(DIRECTORY urdf meshes launch rviz
   DESTINATION share/${PROJECT_NAME})

--- a/src/tractobots_description/package.xml
+++ b/src/tractobots_description/package.xml
@@ -13,7 +13,7 @@
   <url type="repository">https://github.com/cropcrusaders/tractobots.git</url>
   <license>GPLv3</license>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend> <!-- ★ Codex-edit -->
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
## Summary
- ensure CI installs `ros-humble-ros-base` and sources it before building
- silence `AgIsoStackPlusPlus` naming warnings
- mark ament_cmake usage in all CMake packages

## Testing
- `colcon build --symlink-install` *(fails: colcon not installed)*
- `ros2 pkg executables ros2-driver` *(fails: ros2 not installed)*
- `ros2 run ros2-driver driver_node --help` *(fails: ros2 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683a36cf5b4c8321835ef0db2fb1d316