### PR TITLE
Fix CI environment setup

### DIFF
--- a/.github/workflows/ros2-ci.yml
+++ b/.github/workflows/ros2-ci.yml
@@ -49,7 +49,6 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y ros-humble-ros-base
-          echo "source /opt/ros/humble/setup.bash" >> $GITHUB_ENV
           # ★ Codex-edit
 
       # 6. Build the workspace


### PR DESCRIPTION
## Summary
- remove invalid GITHUB_ENV entry in CI workflow

## Testing
- `pytest -q` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_683a3a3aa0c883219dfea97be4c09f44