### PR TITLE
Fix build paths for AgIsoStackPlusPlus

### DIFF
--- a/src/AgIsoStackPlusPlus/CMakeLists.txt
+++ b/src/AgIsoStackPlusPlus/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.22)
 set(CMAKE_WARN_DEPRECATED FALSE) # ★ Codex-edit
-project(AgIsoStackPlusPlus LANGUAGES CXX C)
+project(AgIsoStackPlusPlus LANGUAGES CXX) # ★ Codex-edit
 
 find_package(ament_cmake REQUIRED)
 
@@ -16,6 +16,7 @@ add_library(isobus
 # Public headers
 target_include_directories(isobus PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/isobus> # ★ Codex-edit
   $<INSTALL_INTERFACE:include>
 )
 
@@ -23,13 +24,12 @@ target_link_libraries(isobus PUBLIC pthread)
 
 install(TARGETS isobus
   EXPORT export_isobus
-  LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
 )
 
 install(DIRECTORY include/ DESTINATION include)
 
-ament_export_include_directories(include)
+ament_export_include_directories(include include/isobus) # ★ Codex-edit
 ament_export_libraries(isobus)
 ament_export_targets(export_isobus HAS_LIBRARY_TARGET)
 


### PR DESCRIPTION
## Summary
- tweak project declaration for AgIsoStackPlusPlus vendor library
- export isobus include directory
- install static library

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683a3e89ee6c8321af3e9a50027f6f24