### PR TITLE
Fix AgIsoStackPlusPlus include export

### DIFF
--- a/src/AgIsoStackPlusPlus/CMakeLists.txt
+++ b/src/AgIsoStackPlusPlus/CMakeLists.txt
@@ -15,8 +15,7 @@ add_library(isobus
 
 # Public headers
 target_include_directories(isobus PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/isobus> # ★ Codex-edit
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> # ★ Codex-edit
   $<INSTALL_INTERFACE:include>
 )
 
@@ -29,7 +28,7 @@ install(TARGETS isobus
 
 install(DIRECTORY include/ DESTINATION include)
 
-ament_export_include_directories(include include/isobus) # ★ Codex-edit
+ament_export_include_directories(include) # ★ Codex-edit
 ament_export_libraries(isobus)
 ament_export_targets(export_isobus HAS_LIBRARY_TARGET)
 


### PR DESCRIPTION
## Summary
- ensure AgIsoStack++ headers are exported from `include`
- clean up include path export in CMake

## Testing
- `colcon build --symlink-install` *(fails: `colcon: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683a4691146c83219e5a679796f9c49f