### PR TITLE
Exclude driver sources

### DIFF
--- a/src/AgIsoStackPlusPlus/CMakeLists.txt
+++ b/src/AgIsoStackPlusPlus/CMakeLists.txt
@@ -4,10 +4,11 @@ project(AgIsoStackPlusPlus LANGUAGES CXX) # ★ Codex-edit
 
 find_package(ament_cmake REQUIRED)
 
-file(GLOB_RECURSE ISOBUS_SRC CONFIGURE_DEPENDS
-  "${CMAKE_CURRENT_SOURCE_DIR}/src/Isobus/**/*.cpp") # ★ Codex-edit
+file(GLOB_RECURSE ISOBUS_CORE_SRC CONFIGURE_DEPENDS
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/Isobus/isobus/*.cpp" # ★ Codex-edit
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/Isobus/utility/*.cpp")
 
-add_library(isobus ${ISOBUS_SRC})
+add_library(isobus ${ISOBUS_CORE_SRC}) # ★ Codex-edit
 
 # Public headers
 target_include_directories(isobus PUBLIC


### PR DESCRIPTION
## Summary
- keep building AgIsoStack++ without hardware integration

## Testing
- `colcon build --symlink-install` *(fails: `colcon: command not found`)*
- `source install/setup.bash` *(fails: No such file or directory)*
- `ros2 run ros2-driver driver_node --help` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_683a51f9741483218ac107f647e61ac7