### PR TITLE
Fix path to Advancednavigation sources

### DIFF
--- a/src/Advancednavigation/CMakeLists.txt
+++ b/src/Advancednavigation/CMakeLists.txt
@@ -22,7 +22,13 @@ find_package(sensor_msgs REQUIRED)
 find_package(diagnostic_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 
-add_executable(adnav_driver src/advanced_navigation_driver.cpp src/rs232/rs232.c src/an_packet_protocol.c src/spatial_packets.c src/NTRIP_Client/NTRIP/ntripclient.c)
+add_executable(adnav_driver
+  Src/advanced_navigation_driver.cpp
+  Src/Rs232/rs232.c
+  Src/an_packet_protocol.c
+  Src/spatial_packets.c
+  Src/NTRIP_Client/NTRIP/ntripclient.c
+) # ★ Codex-edit
 ament_target_dependencies(adnav_driver rclcpp std_msgs sensor_msgs diagnostic_msgs geometry_msgs)
 
 install(TARGETS


### PR DESCRIPTION
## Summary
- fix `ros2-driver` build paths

## Testing
- `colcon build --symlink-install` *(fails: command not found)*
- `source install/setup.bash && ros2 run ros2-driver adnav_driver --help` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a54862e4c83218d713c7c3e6aba6a