### PR TITLE
Fix ros2-driver source list

### DIFF
--- a/src/Advancednavigation/CMakeLists.txt
+++ b/src/Advancednavigation/CMakeLists.txt
@@ -22,8 +22,12 @@ find_package(sensor_msgs REQUIRED)
 find_package(diagnostic_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 
+file(GLOB DRIVER_CPP_SOURCES
+  "Src/*.cpp"
+) # ★ Codex-edit
+
 add_executable(adnav_driver
-  Src/advanced_navigation_driver.cpp
+  ${DRIVER_CPP_SOURCES}
   Src/Rs232/rs232.c
   Src/an_packet_protocol.c
   Src/spatial_packets.c


### PR DESCRIPTION
## Summary
- automatically collect driver `.cpp` files in CMake
- keep dependency and install rules intact

## Testing
- `colcon build --symlink-install`
- `source install/setup.bash`
- `ros2 run ros2-driver adnav_driver --help`


------
https://chatgpt.com/codex/tasks/task_e_683a58a1681483219af920b58589f39a