### PR TITLE
Add ament_python scaffolding for tractobots_launchers

### DIFF
--- a/src/tractobots_launchers/MANIFEST.in
+++ b/src/tractobots_launchers/MANIFEST.in
@@ -1,0 +1,3 @@
+include package.xml
+include resource/tractobots_launchers
+recursive-include launch *.py

--- a/src/tractobots_launchers/resource/tractobots_launchers
+++ b/src/tractobots_launchers/resource/tractobots_launchers
@@ -1,1 +1,1 @@
-
+tractobots_launchers

--- a/src/tractobots_launchers/setup.py
+++ b/src/tractobots_launchers/setup.py
@@ -1,0 +1,22 @@
+from glob import glob
+from setuptools import setup, find_packages
+
+package_name = 'tractobots_launchers'
+
+setup(
+    name=package_name,
+    version='0.0.1',
+    packages=find_packages(),
+    data_files=[
+        ('share/ament_index/resource_index/packages', ['resource/' + package_name]),
+        ('share/' + package_name, ['package.xml']),
+        ('share/' + package_name + '/launch', glob('launch/*.py')),
+    ],
+    install_requires=['setuptools'],
+    zip_safe=True,
+    maintainer='Kyler Laird',
+    maintainer_email='KylerLaird@todo.com',
+    description='Top-level launch files that start the whole Tractobots stack.',
+    license='GPLv3',
+    entry_points={},
+)


### PR DESCRIPTION
## Summary
- convert `tractobots_launchers` to an ament_python package
- install launch files with `setup.py`
- add MANIFEST.in and Python package
- include explicit resource marker

## Testing
- `colcon build --symlink-install` *(fails: `colcon` not found)*
- `ros2 --help` *(fails: `ros2` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a5ed6b9f883219755f6ded1c194f5