### PR TITLE
Fix ros2-driver diagnostic dep

### DIFF
--- a/src/Advancednavigation/CMakeLists.txt
+++ b/src/Advancednavigation/CMakeLists.txt
@@ -41,6 +41,7 @@ target_include_directories(adnav_driver PUBLIC
 ament_target_dependencies(adnav_driver
   rclcpp sensor_msgs geometry_msgs
   tf2 tf2_ros tf2_geometry_msgs
+  diagnostic_msgs            # ★ Codex-edit (new)
 ) # ★ Codex-edit
 
 install(TARGETS

--- a/src/Advancednavigation/package.xml
+++ b/src/Advancednavigation/package.xml
@@ -19,6 +19,8 @@
   <exec_depend>tf2</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
   <exec_depend>tf2_geometry_msgs</exec_depend>
+  <build_depend>diagnostic_msgs</build_depend> <!-- ★ Codex-edit (new) -->
+  <exec_depend>diagnostic_msgs</exec_depend> <!-- ★ Codex-edit (new) -->
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
## Summary
- add diagnostic_msgs to adnav_driver's linked libraries
- register diagnostic_msgs as build and exec dependency

## Testing
- `colcon build --symlink-install` *(fails: command not found)*
- `source install/setup.bash`
- `ros2 run ros2-driver adnav_driver --help` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a61bdccfc8321962809799d153557