### PR TITLE
Remove redundant diagnostic_msgs depend

### DIFF
--- a/src/Advancednavigation/package.xml
+++ b/src/Advancednavigation/package.xml
@@ -11,7 +11,7 @@
   <depend>rclcpp</depend>
   <depend>std_msgs</depend>
   <depend>sensor_msgs</depend>
-  <depend>diagnostic_msgs</depend>
+  <!-- ★ Codex-edit removed redundant depend -->
   <depend>geometry_msgs</depend>
   <build_depend>tf2</build_depend>
   <build_depend>tf2_ros</build_depend>


### PR DESCRIPTION
## Summary
- remove redundant `<depend>diagnostic_msgs</depend>` from ros2-driver `package.xml`

## Testing
- `colcon build`
- `colcon test`

------
https://chatgpt.com/codex/tasks/task_e_683a6624c7cc8321afe277f18f943e00