### PR TITLE
Fix iso_bus_watchdog build

### DIFF
--- a/src/Iso_bus_watchdog/CMakeLists.txt
+++ b/src/Iso_bus_watchdog/CMakeLists.txt
@@ -12,6 +12,9 @@ add_executable(iso_bus_watchdog_node
   src/iso_bus_watchdog_node.cpp
 )
 
+target_link_libraries(iso_bus_watchdog_node isobus) # ★ Codex-edit
+ament_target_dependencies(iso_bus_watchdog_node rclcpp diagnostic_msgs isobus) # ★ Codex-edit
+
 ament_target_dependencies(iso_bus_watchdog_node
   rclcpp
   std_msgs

--- a/src/Iso_bus_watchdog/package.xml
+++ b/src/Iso_bus_watchdog/package.xml
@@ -11,6 +11,10 @@
   <depend>rclcpp</depend>
   <depend>std_msgs</depend>
   <depend>AgIsoStackPlusPlus</depend>
+  <build_depend>AgIsoStackPlusPlus</build_depend> # ★ Codex-edit
+  <exec_depend>AgIsoStackPlusPlus</exec_depend> # ★ Codex-edit
+  <build_depend>diagnostic_msgs</build_depend> # ★ Codex-edit
+  <exec_depend>diagnostic_msgs</exec_depend> # ★ Codex-edit
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
## Summary
- link iso_bus_watchdog_node with isobus library
- declare AgIsoStackPlusPlus and diagnostic_msgs package dependencies

## Testing
- `colcon build --symlink-install` *(fails: command not found)*
- `ros2 run iso_bus_watchdog iso_bus_watchdog_node --help` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a688ec45c8321852bdb57ba959f52