### PR TITLE
Fix duplicate dependency in ISO bus watchdog

### DIFF
--- a/src/Iso_bus_watchdog/package.xml
+++ b/src/Iso_bus_watchdog/package.xml
@@ -10,7 +10,6 @@
 
   <depend>rclcpp</depend>
   <depend>std_msgs</depend>
-  <depend>AgIsoStackPlusPlus</depend>
   <build_depend>AgIsoStackPlusPlus</build_depend> # ★ Codex-edit
   <exec_depend>AgIsoStackPlusPlus</exec_depend> # ★ Codex-edit
   <build_depend>diagnostic_msgs</build_depend> # ★ Codex-edit


### PR DESCRIPTION
## Summary
- remove redundant `depend` entry for `AgIsoStackPlusPlus` in iso_bus_watchdog

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683a71566fbc832180deb8fc786109b2