### PR TITLE
Add missing main to gcode_reader_node

### DIFF
--- a/src/Gcode_parser/Src/gcode_reader_node.cpp
+++ b/src/Gcode_parser/Src/gcode_reader_node.cpp
@@ -39,3 +39,12 @@ void GCodeReaderNode::loadGCodeAndPublish() {
     RCLCPP_INFO(this->get_logger(), "Publishing G-code path with %zu waypoints", path_msg.poses.size());
     path_pub_->publish(path_msg);
 }
+
+int main(int argc, char **argv)
+{
+    rclcpp::init(argc, argv);
+    auto node = std::make_shared<GCodeReaderNode>();
+    rclcpp::spin(node);
+    rclcpp::shutdown();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add an entry point so `gcode_reader_node` can build as an executable

## Testing
- `colcon --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a77324c60832199a5d890a64a276a