### PR TITLE
Fix stray diagnostic msgs dep in iso_bus_watchdog

### DIFF
--- a/src/Iso_bus_watchdog/CMakeLists.txt
+++ b/src/Iso_bus_watchdog/CMakeLists.txt
@@ -13,7 +13,7 @@ add_executable(iso_bus_watchdog_node
 )
 
 target_link_libraries(iso_bus_watchdog_node isobus) # ★ Codex-edit
-ament_target_dependencies(iso_bus_watchdog_node rclcpp diagnostic_msgs isobus) # ★ Codex-edit
+ament_target_dependencies(iso_bus_watchdog_node rclcpp isobus) # ★ Codex-edit
 
 ament_target_dependencies(iso_bus_watchdog_node
   rclcpp

--- a/src/Iso_bus_watchdog/package.xml
+++ b/src/Iso_bus_watchdog/package.xml
@@ -12,8 +12,6 @@
   <depend>std_msgs</depend>
   <build_depend>AgIsoStackPlusPlus</build_depend> # ★ Codex-edit
   <exec_depend>AgIsoStackPlusPlus</exec_depend> # ★ Codex-edit
-  <build_depend>diagnostic_msgs</build_depend> # ★ Codex-edit
-  <exec_depend>diagnostic_msgs</exec_depend> # ★ Codex-edit
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
## Summary
- remove unused diagnostic_msgs dependency from iso_bus_watchdog

## Testing
- `colcon build --symlink-install` *(fails: `colcon: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683a7bc000e48321901e06bd90e5c797