### PR TITLE
Fix global variable collision in ros2-driver

### DIFF
--- a/src/Advancednavigation/Src/NTRIP_Client/NTRIP/ntripclient.c
+++ b/src/Advancednavigation/Src/NTRIP_Client/NTRIP/ntripclient.c
@@ -27,7 +27,7 @@
 static char revisionstr[] = "$Revision: 1.51 $";
 static char datestr[]     = "$Date: 2009/09/11 09:49:19 $";
 
-int error = 0;
+static int error = 0; /* ★ Codex-edit: made static to avoid symbol clash across files */
 int sleeptime = 0;
 long i;
 sockettype sockfd = 0;

--- a/src/Advancednavigation/Src/rs232/rs232.c
+++ b/src/Advancednavigation/Src/rs232/rs232.c
@@ -38,8 +38,8 @@
 #ifdef __linux__   /* Linux */
 
 
-int Cport,
-    error;
+int Cport;
+static int error; /* ★ Codex-edit: made static to avoid symbol clash across files */
 
 struct termios new_port_settings,
        old_port_settings;


### PR DESCRIPTION
## Summary
- avoid cross-file `error` variable collisions by making them static

## Testing
- `colcon build --symlink-install` *(fails: command not found)*
- `ros2 run ros2-driver adnav_driver --help` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_683a7ea674488321b9e654883ed3d34f