### PR TITLE
Link watchdog node to isobus

### DIFF
--- a/src/Iso_bus_watchdog/CMakeLists.txt
+++ b/src/Iso_bus_watchdog/CMakeLists.txt
@@ -13,12 +13,11 @@ add_executable(iso_bus_watchdog_node
 )
 
 target_link_libraries(iso_bus_watchdog_node isobus) # ★ Codex-edit
-ament_target_dependencies(iso_bus_watchdog_node rclcpp isobus) # ★ Codex-edit
 
 ament_target_dependencies(iso_bus_watchdog_node
   rclcpp
   std_msgs
-)
+) # ★ Codex-edit
 
 # link pthreads for AgIsoStack++
 target_link_libraries(iso_bus_watchdog_node


### PR DESCRIPTION
## Summary
- link watchdog node to isobus library in its CMakeLists

## Testing
- `colcon build --symlink-install` *(fails: `colcon` not found)*
- `source install/setup.bash` *(fails: file not found)*
- `ros2 run iso_bus_watchdog iso_bus_watchdog_node --help` *(fails: `ros2` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a80dc3f448321b6a3cb2b13b54cc6