### PR TITLE
Limit AgIsoStackPlusPlus build to core

### DIFF
--- a/src/AgIsoStackPlusPlus/CMakeLists.txt
+++ b/src/AgIsoStackPlusPlus/CMakeLists.txt
@@ -4,12 +4,10 @@ project(AgIsoStackPlusPlus LANGUAGES CXX) # ★ Codex-edit
 
 find_package(ament_cmake REQUIRED)
 
-file(GLOB_RECURSE ISOBUS_CORE_SRC CONFIGURE_DEPENDS
-  "${CMAKE_CURRENT_SOURCE_DIR}/src/Isobus/isobus/*.cpp" # ★ Codex-edit
-  "${CMAKE_CURRENT_SOURCE_DIR}/src/Isobus/utility/*.cpp"
-  "${CMAKE_CURRENT_SOURCE_DIR}/src/Isobus/hardware_integration/*.cpp")
+file(GLOB_RECURSE ISOBUS_SRC CONFIGURE_DEPENDS
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/Isobus/isobus/*.cpp") # ★ Codex-edit
 
-add_library(isobus ${ISOBUS_CORE_SRC}) # ★ Codex-edit
+add_library(isobus ${ISOBUS_SRC}) # ★ Codex-edit
 
 # Public headers
 target_include_directories(isobus PUBLIC


### PR DESCRIPTION
## Summary
- restrict AgIsoStackPlusPlus sources to cross-platform files only

## Testing
- `colcon build --symlink-install` *(fails: `colcon: command not found`)*
- `source install/setup.bash` *(fails: `No such file or directory`)*
- `ros2 run iso_bus_watchdog iso_bus_watchdog_node --help` *(fails: `command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683a8bcbef288321a477ed2172f9cbb8