### PR TITLE
Fix iso_bus_watchdog build deps

### DIFF
--- a/src/Iso_bus_watchdog/CMakeLists.txt
+++ b/src/Iso_bus_watchdog/CMakeLists.txt
@@ -12,17 +12,15 @@ add_executable(iso_bus_watchdog_node
   src/iso_bus_watchdog_node.cpp
 )
 
-target_link_libraries(iso_bus_watchdog_node isobus) # ★ Codex-edit
-
 ament_target_dependencies(iso_bus_watchdog_node
   rclcpp
   std_msgs
+  AgIsoStackPlusPlus
 ) # ★ Codex-edit
 
 # link pthreads for AgIsoStack++
 target_link_libraries(iso_bus_watchdog_node
   Threads::Threads
-  isobus
 )
 
 install(TARGETS iso_bus_watchdog_node


### PR DESCRIPTION
## Summary
- fix iso_bus_watchdog build dependencies so AgIsoStackPlusPlus headers are found

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683a91aa141c832188f5f0b887e26bbe