### PR TITLE
Fix ISO watchdog publishing

### DIFF
--- a/src/AgIsoStackPlusPlus/include/isobus/utility/lock_free_queue.hpp
+++ b/src/AgIsoStackPlusPlus/include/isobus/utility/lock_free_queue.hpp
@@ -1,0 +1,185 @@
+#ifndef LOCK_FREE_QUEUE_HPP
+#define LOCK_FREE_QUEUE_HPP
+
+#if defined CAN_STACK_DISABLE_THREADS || defined ARDUINO
+#include <queue>
+
+namespace isobus
+{
+        /// @brief A template class for a queue when threading is disabled.
+        /// @tparam T The item type for the queue.
+        template<typename T>
+        class LockFreeQueue
+        {
+        public:
+                /// @brief Constructor for the lock free queue.
+                explicit LockFreeQueue(std::size_t) {}
+
+                /// @brief Push an item to the queue.
+                /// @param item The item to push to the queue.
+                /// @return Simply returns true, since this version is unlimited in size.
+                bool push(const T &item)
+                {
+                        queue.push(item);
+                        return true;
+                }
+
+                /// @brief Peek at the next item in the queue.
+                /// @param item The item to peek at in the queue.
+                /// @return True if the item was peeked at in the queue, false if the queue is empty.
+                bool peek(T &item)
+                {
+                        if (queue.empty())
+                        {
+                                return false;
+                        }
+
+                        item = queue.front();
+                        return true;
+                }
+
+                /// @brief Pop an item from the queue.
+                /// @return True if the item was popped from the queue, false if the queue is empty.
+                bool pop()
+                {
+                        if (queue.empty())
+                        {
+                                return false;
+                        }
+
+                        queue.pop();
+                        return true;
+                }
+
+                /// @brief Check if the queue is full.
+                /// @return Always returns false, since this version of the queue is not limited in size.
+                bool is_full() const
+                {
+                        return false;
+                }
+
+                /// @brief Clear the queue.
+                void clear()
+                {
+                        queue = {};
+                }
+
+        private:
+                std::queue<T> queue; ///< The queue
+        };
+
+} // namespace isobus
+
+#else // CAN_STACK_DISABLE_THREADS
+
+#include <atomic>
+#include <cassert>
+#include <mutex>
+#include <vector>
+
+namespace isobus
+{
+        using Mutex = std::mutex;
+        using RecursiveMutex = std::recursive_mutex;
+}
+
+/// @brief A template class for a lock free queue.
+/// @tparam T The item type for the queue.
+template<typename T>
+class LockFreeQueue
+{
+public:
+        /// @brief Constructor for the lock free queue.
+        explicit LockFreeQueue(std::size_t size) :
+          buffer(size), capacity(size)
+        {
+                // Validate the size of the queue, if assertion is disabled, set the size to 1.
+                assert(size > 0 && "The size of the queue must be greater than 0.");
+                if (size == 0)
+                {
+                        size = 1;
+                }
+        }
+
+        /// @brief Push an item to the queue.
+        /// @param item The item to push to the queue.
+        /// @return True if the item was pushed to the queue, false if the queue is full.
+        bool push(const T &item)
+        {
+                const auto currentWriteIndex = writeIndex.load(std::memory_order_relaxed);
+                const auto nextWriteIndex = nextIndex(currentWriteIndex);
+
+                if (nextWriteIndex == readIndex.load(std::memory_order_acquire))
+                {
+                        // The buffer is full.
+                        return false;
+                }
+
+                buffer[currentWriteIndex] = item;
+                writeIndex.store(nextWriteIndex, std::memory_order_release);
+                return true;
+        }
+
+        /// @brief Peek at the next item in the queue.
+        /// @param item The item to peek at in the queue.
+        /// @return True if the item was peeked at in the queue, false if the queue is empty.
+        bool peek(T &item)
+        {
+                const auto currentReadIndex = readIndex.load(std::memory_order_relaxed);
+                if (currentReadIndex == writeIndex.load(std::memory_order_acquire))
+                {
+                        // The buffer is empty.
+                        return false;
+                }
+
+                item = buffer[currentReadIndex];
+                return true;
+        }
+
+        /// @brief Pop an item from the queue.
+        /// @return True if the item was popped from the queue, false if the queue is empty.
+        bool pop()
+        {
+                const auto currentReadIndex = readIndex.load(std::memory_order_relaxed);
+                if (currentReadIndex == writeIndex.load(std::memory_order_acquire))
+                {
+                        // The buffer is empty.
+                        return false;
+                }
+
+                readIndex.store(nextIndex(currentReadIndex), std::memory_order_release);
+                return true;
+        }
+
+        /// @brief Check if the queue is full.
+        /// @return True if the queue is full, false if the queue is not full.
+        bool is_full() const
+        {
+                return nextIndex(writeIndex.load(std::memory_order_acquire)) == readIndex.load(std::memory_order_acquire);
+        }
+
+        /// @brief Clear the queue.
+        void clear()
+        {
+                // Simply move the read index to the write index.
+                readIndex.store(writeIndex.load(std::memory_order_acquire), std::memory_order_release);
+        }
+
+private:
+        std::vector<T> buffer; ///< The buffer for the circular buffer.
+        std::atomic<std::size_t> readIndex = { 0 }; ///< The read index for the circular buffer.
+        std::atomic<std::size_t> writeIndex = { 0 }; ///< The write index for the circular buffer.
+        const std::size_t capacity; ///< The capacity of the circular buffer.
+
+        /// @brief Get the next index in the circular buffer.
+        /// @param current The current index.
+        /// @return The next index in the circular buffer.
+        std::size_t nextIndex(std::size_t current) const
+        {
+                return (current + 1) % capacity;
+        }
+};
+
+#endif // CAN_STACK_DISABLE_THREADS
+
+#endif // LOCK_FREE_QUEUE_HPP

--- a/src/Iso_bus_watchdog/src/iso_bus_watchdog_node.cpp
+++ b/src/Iso_bus_watchdog/src/iso_bus_watchdog_node.cpp
@@ -118,9 +118,17 @@ private:
     float temp = d[5] - 40.0f;  // SPN 110 (1 °C/bit, –40 °C offset)
 
     // Publish readings
-    pub_oil_->publish(std_msgs::msg::Float32{oil});
-    pub_fuel_->publish(std_msgs::msg::Float32{fuel});
-    pub_temp_->publish(std_msgs::msg::Float32{temp});
+    std_msgs::msg::Float32 oil_msg;
+    oil_msg.data = oil;
+    pub_oil_->publish(oil_msg);
+
+    std_msgs::msg::Float32 fuel_msg;
+    fuel_msg.data = fuel;
+    pub_fuel_->publish(fuel_msg);
+
+    std_msgs::msg::Float32 temp_msg;
+    temp_msg.data = temp;
+    pub_temp_->publish(temp_msg);
 
     // Update freshness
     last_oil_  = last_fuel_  = last_temp_  = now;
@@ -137,7 +145,9 @@ private:
     auto now = std::chrono::steady_clock::now();
     float level = msg.get_data()[0] * 0.4f; // SPN 96 (0.4 %/bit)
 
-    pub_level_->publish(std_msgs::msg::Float32{level});
+    std_msgs::msg::Float32 level_msg;
+    level_msg.data = level;
+    pub_level_->publish(level_msg);
     last_level_ = now;
 
     if (level < level_min_ || level > level_max_) {


### PR DESCRIPTION
## Summary
- add missing `lock_free_queue.hpp` header to isobus utility
- fix publishing of `std_msgs::msg::Float32` in iso_bus_watchdog_node

## Testing
- `colcon build --symlink-install` *(fails: command not found)*
- `ros2 run iso_bus_watchdog iso_bus_watchdog_node --help` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a9d056a208321bb21485bc5d63832