### PR TITLE
Restore threading headers

### DIFF
--- a/src/AgIsoStackPlusPlus/include/isobus/hardware_integration/can_hardware_interface.hpp
+++ b/src/AgIsoStackPlusPlus/include/isobus/hardware_integration/can_hardware_interface.hpp
@@ -14,6 +14,7 @@
 #include "isobus/isobus/can_hardware_abstraction.hpp"
 #include "isobus/isobus/can_message_frame.hpp"
 #include "isobus/utility/event_dispatcher.hpp"
+#include "isobus/utility/thread_synchronization.hpp" // ★ Codex-edit
 
 #include <atomic>
 #include <cstdint>


### PR DESCRIPTION
## Summary
- ensure CAN interface gets thread primitives

## Testing
- `g++ -std=c++17 -I src/AgIsoStackPlusPlus/include -c -x c++ - <<'EOF'
#include "isobus/hardware_integration/can_hardware_interface.hpp"
int main() { return 0; }
EOF`
- `colcon build --symlink-install` *(fails: command not found)*
- `ros2 run iso_bus_watchdog iso_bus_watchdog_node --help` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a9fc427688321afcac478373c9f45