### PR TITLE
Fix SystemTiming header

### DIFF
--- a/src/AgIsoStackPlusPlus/include/isobus/utility/system_timing.hpp
+++ b/src/AgIsoStackPlusPlus/include/isobus/utility/system_timing.hpp
@@ -1,22 +1,35 @@
 #ifndef ISOBUS_SYSTEM_TIMING_HPP
 #define ISOBUS_SYSTEM_TIMING_HPP
 
-#include <chrono>
 #include <cstdint>
 
-namespace isobus {
+namespace isobus
+{
+    /**
+     * @brief Utility class providing time related helper functions.
+     *
+     * This interface matches the upstream AgIsoStack library so that the
+     * implementations in the src directory can be used without modification.
+     */
+    class SystemTiming
+    {
+    public:
+        static std::uint32_t get_timestamp_ms();
+        static std::uint64_t get_timestamp_us();
 
-class SystemTiming {
-public:
-    static std::uint32_t get_timestamp_ms() {
-        auto now = std::chrono::steady_clock::now().time_since_epoch();
-        return static_cast<std::uint32_t>(std::chrono::duration_cast<std::chrono::milliseconds>(now).count());
-    }
-    static bool time_expired_ms(std::uint32_t start, std::uint32_t interval) {
-        std::uint32_t now = get_timestamp_ms();
-        return now - start >= interval;
-    }
-};
+        static std::uint32_t get_time_elapsed_ms(std::uint32_t timestamp_ms);
+        static std::uint64_t get_time_elapsed_us(std::uint64_t timestamp_us);
+
+        static bool time_expired_ms(std::uint32_t timestamp_ms, std::uint32_t timeout_ms);
+        static bool time_expired_us(std::uint64_t timestamp_us, std::uint64_t timeout_us);
+
+    private:
+        static std::uint32_t incrementing_difference(std::uint32_t currentValue, std::uint32_t previousValue);
+        static std::uint64_t incrementing_difference(std::uint64_t currentValue, std::uint64_t previousValue);
+
+        static std::uint64_t s_timestamp_ms;
+        static std::uint64_t s_timestamp_us;
+    };
 
 } // namespace isobus
 


### PR DESCRIPTION
## Summary
- declare full SystemTiming interface so AgIsoStack builds

## Testing
- `colcon build --packages-select AgIsoStackPlusPlus` *(fails: `colcon` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ab243a9ec8321b221d5a32c496b98