### PR TITLE
Fix event dispatcher and string conversion

### DIFF
--- a/src/AgIsoStackPlusPlus/include/isobus/utility/event_dispatcher.hpp
+++ b/src/AgIsoStackPlusPlus/include/isobus/utility/event_dispatcher.hpp
@@ -43,6 +43,11 @@ public:
 
     void call(Args... args) { invoke(args...); }
 
+    std::size_t get_listener_count() const
+    {
+        return listeners.size();
+    }
+
 private:
     std::unordered_map<EventCallbackHandle, Callback> listeners;
     EventCallbackHandle nextHandle{0};

--- a/src/AgIsoStackPlusPlus/include/isobus/utility/to_string.hpp
+++ b/src/AgIsoStackPlusPlus/include/isobus/utility/to_string.hpp
@@ -6,8 +6,19 @@
 namespace isobus {
 
 template<typename T>
-std::string to_string(T value) {
+std::string to_string(T value)
+{
     return std::to_string(value);
+}
+
+inline std::string to_string(const std::string &value)
+{
+    return value;
+}
+
+inline std::string to_string(const char *value)
+{
+    return std::string(value);
 }
 
 } // namespace isobus


### PR DESCRIPTION
## Summary
- add `get_listener_count` to `EventDispatcher`
- extend `to_string` helper to handle `std::string` and `const char*`

## Testing
- `colcon build --packages-select AgIsoStackPlusPlus` *(fails: `colcon` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ab7b734e88321bd8c13f274ea52b6