### PR TITLE
Fix AgIsoStack++ build on Linux

### DIFF
--- a/src/AgIsoStackPlusPlus/CMakeLists.txt
+++ b/src/AgIsoStackPlusPlus/CMakeLists.txt
@@ -9,6 +9,20 @@ file(GLOB ISOBUS_CORE_SRC CONFIGURE_DEPENDS
 file(GLOB HARDWARE_SRC CONFIGURE_DEPENDS
   "${CMAKE_CURRENT_SOURCE_DIR}/src/Isobus/hardware_integration/*.cpp")
 
+# Remove platform specific drivers that are not buildable on Linux
+list(REMOVE_ITEM HARDWARE_SRC
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/Isobus/hardware_integration/flex_can_t4_plugin.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/Isobus/hardware_integration/innomaker_usb2can_windows_plugin.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/Isobus/hardware_integration/mac_can_pcan_plugin.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/Isobus/hardware_integration/pcan_basic_windows_plugin.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/Isobus/hardware_integration/sys_tec_windows_plugin.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/Isobus/hardware_integration/mcp2515_can_interface.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/Isobus/hardware_integration/ntcan_plugin.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/Isobus/hardware_integration/spi_interface_esp.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/Isobus/hardware_integration/twai_plugin.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/Isobus/hardware_integration/toucan_vscp_canal.cpp"
+)
+
 file(GLOB UTILITY_SRC CONFIGURE_DEPENDS
   "${CMAKE_CURRENT_SOURCE_DIR}/src/utility/*.cpp")
 

--- a/src/AgIsoStackPlusPlus/include/Arduino.h
+++ b/src/AgIsoStackPlusPlus/include/Arduino.h
@@ -1,0 +1,33 @@
+#ifndef ARDUINO_STUB_H
+#define ARDUINO_STUB_H
+
+#include <cstdint>
+#include <cstddef>
+#include <chrono>
+#include <thread>
+
+inline void delay(unsigned long ms)
+{
+    std::this_thread::sleep_for(std::chrono::milliseconds(ms));
+}
+
+inline unsigned long millis()
+{
+    static auto start = std::chrono::steady_clock::now();
+    auto now = std::chrono::steady_clock::now();
+    return static_cast<unsigned long>(std::chrono::duration_cast<std::chrono::milliseconds>(now - start).count());
+}
+
+class HardwareSerial
+{
+public:
+    template<typename T>
+    void print(const T &) {}
+
+    template<typename T>
+    void println(const T &) {}
+};
+
+static HardwareSerial Serial;
+
+#endif // ARDUINO_STUB_H


### PR DESCRIPTION
## Summary
- add an Arduino.h stub so the library can build outside of Arduino
- exclude Windows- and microcontroller-specific drivers from the AgIsoStack++ build

## Testing
- `colcon build --packages-select AgIsoStackPlusPlus` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683abe65c0808321a11255bd3dc0e41f