### PR TITLE
Fix ament_cmake_test import error

### DIFF
--- a/.github/workflows/ros2-ci.yml
+++ b/.github/workflows/ros2-ci.yml
@@ -37,6 +37,16 @@ jobs:
           sudo apt update
           sudo apt install -y python3-pytest
 
+      # Install tools required for running package tests and linters
+      - name: Install test dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y \
+            python3-ament-cmake \
+            ros-humble-ament-lint-auto \
+            ros-humble-ament-lint-common
+          source /opt/ros/humble/setup.bash
+
       # 4. Install ROS 2 package dependencies
       - name: rosdep install
         run: |

--- a/src/Advancednavigation/package.xml
+++ b/src/Advancednavigation/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros2-driver</name>
-  <version>2.0.0</version>
+  <version>2.0.1</version>
   <description>Advanced Navigation ROS 2 Driver</description>
   <maintainer email="support@advancednavigation.com">Support</maintainer>
   <license>MIT</license>
@@ -24,6 +24,8 @@
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_cmake_test</test_depend>
+  <exec_depend>ament_lint_auto</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/src/Gcode_parser/package.xml
+++ b/src/Gcode_parser/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>gcode_parser</name>
-  <version>0.1.0</version>
+  <version>0.1.1</version>
   <description>G-code parser library and reader node.</description>
   <maintainer email="KylerLaird@todo.com">Kyler Laird</maintainer>
   <license>GPLv3</license>
@@ -15,6 +15,8 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_cmake_test</test_depend>
+  <exec_depend>ament_lint_auto</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
## Summary
- install ament-cmake and ament-lint tools during CI
- declare ament_cmake_test as a test dependency
- bump gcode_parser and ros2-driver patch versions

## Testing
- `colcon test --event-handlers console_cohesion+ --packages-select gcode_parser ros2-driver` *(fails: `colcon: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683ac52ac08883219c4fe8d8db841a85