### PR TITLE
Fix ament dependency install in workflow

### DIFF
--- a/.github/workflows/ros2-ci.yml
+++ b/.github/workflows/ros2-ci.yml
@@ -42,7 +42,9 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y \
-            python3-ament-cmake \
+            ros-humble-ament-cmake \
+            ros-humble-ament-cmake-gtest \
+            ros-humble-ament-cmake-pytest \
             ros-humble-ament-lint-auto \
             ros-humble-ament-lint-common
           source /opt/ros/humble/setup.bash


### PR DESCRIPTION
## Summary
- fix apt installation for ROS 2 test tools

## Testing
- `pytest -q`
- `sudo apt-get install python3-ament-cmake` *(fails: unable to locate package)*


------
https://chatgpt.com/codex/tasks/task_e_683ac7bb73688321baef284523f92ef3