### PR TITLE
Fix CI ament test helpers

### DIFF
--- a/.github/workflows/ros2-ci.yml
+++ b/.github/workflows/ros2-ci.yml
@@ -43,11 +43,13 @@ jobs:
           sudo apt update
           sudo apt install -y \
             ros-humble-ament-cmake \
+            ros-humble-ament-cmake-test \
             ros-humble-ament-cmake-gtest \
             ros-humble-ament-cmake-pytest \
             ros-humble-ament-lint-auto \
             ros-humble-ament-lint-common
           source /opt/ros/humble/setup.bash
+          echo "PYTHONPATH=$PYTHONPATH"
 
       # 4. Install ROS 2 package dependencies
       - name: rosdep install
@@ -61,7 +63,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y ros-humble-ros-base
-          # ★ Codex-edit
+          source /opt/ros/humble/setup.bash
 
       # 6. Build the workspace
       - name: Colcon build
@@ -72,5 +74,6 @@ jobs:
       # 7. Run tests and report results
       - name: Colcon test
         run: |
+          source /opt/ros/humble/setup.bash
           colcon test --event-handlers console_direct+
           colcon test-result --verbose

--- a/docs/CODEX_GUIDE.md
+++ b/docs/CODEX_GUIDE.md
@@ -15,6 +15,15 @@ up all required packages is to run the helper script in the repository root:
 It installs ROS 2, Python build tools, and initializes `rosdep`. Make sure to
 `source /opt/ros/humble/setup.bash` after installation.
 
+If you plan to run the package tests or linters, also install the ROS 2
+`ament_*` helpers:
+
+```bash
+sudo apt install ros-humble-ament-cmake-test \
+  ros-humble-ament-cmake-gtest ros-humble-ament-cmake-pytest \
+  ros-humble-ament-lint-auto ros-humble-ament-lint-common
+```
+
 ## 2. Building the Workspace
 
 Clone the repository inside a ROS 2 workspace and build with `colcon`:
@@ -42,7 +51,13 @@ Additional launch files exist for MapViz and pose transforms.
 ## 4. Running Tests
 
 Some packages include unit tests using `pytest` or `ament_cmake`. After
-building the workspace, tests can be executed with:
+building the workspace, ensure the ROS environment is sourced:
+
+```bash
+source /opt/ros/humble/setup.bash
+```
+
+Then run the tests with:
 
 ```bash
 colcon test


### PR DESCRIPTION
## Summary
- install ament test helper packages in CI
- source ROS setup for test steps
- document installing ament helpers and sourcing ROS before running tests

## Testing
- `colcon test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683acb1b40708321accb633df6790236