### PR TITLE
Fix CI by reinstalling ament test packages

### DIFF
--- a/.github/workflows/ros2-ci.yml
+++ b/.github/workflows/ros2-ci.yml
@@ -70,7 +70,17 @@ jobs:
         run: |
           source /opt/ros/humble/setup.bash
           colcon build --symlink-install
-          # ★ Codex-edit
+
+      # Restore missing ament-cmake-test helpers
+      - name: Reinstall test helpers
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y \
+            ros-humble-ament-cmake \
+            ros-humble-ament-cmake-test \
+            ros-humble-ament-lint-auto \
+            ros-humble-ament-lint-common
+          source /opt/ros/humble/setup.bash && env
       # 7. Run tests and report results
       - name: Colcon test
         run: |


### PR DESCRIPTION
## Summary
- restore `ament_cmake_test` helpers before running `colcon test`

## Testing
- `sudo apt update` *(fails: no network)*

------
https://chatgpt.com/codex/tasks/task_e_683acf95e0cc83219d8c1510d7616ff5