### PR TITLE
Disable ament linters via toggle

### DIFF
--- a/.github/workflows/ros2-ci.yml
+++ b/.github/workflows/ros2-ci.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Colcon build
         run: |
           source /opt/ros/humble/setup.bash
-          colcon build --symlink-install
+          colcon build --symlink-install -D ENABLE_LINTING=OFF
 
       # Restore missing ament-cmake-test helpers
       - name: Reinstall test helpers
@@ -85,5 +85,5 @@ jobs:
       - name: Colcon test
         run: |
           source /opt/ros/humble/setup.bash
-          colcon test --event-handlers console_direct+
+          colcon test --event-handlers console_direct+ -D ENABLE_LINTING=OFF
           colcon test-result --verbose

--- a/src/Advancednavigation/CMakeLists.txt
+++ b/src/Advancednavigation/CMakeLists.txt
@@ -54,14 +54,19 @@ install(
 ) # ★ Codex-edit
 
 if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  # the following line skips the linter which checks for copyrights
-  # uncomment the line when a copyright and license is not present in all source files
-  #set(ament_cmake_copyright_FOUND TRUE)
-  # the following line skips cpplint (only works in a git repo)
-  # uncomment the line when this package is not in a git repo
-  #set(ament_cmake_cpplint_FOUND TRUE)
-  ament_lint_auto_find_test_dependencies()
+
+  #
+  # ─── LINTING TOGGLE ────────────────────────────────────────────────────────────
+  #
+
+  # Turn OFF in CI while code style is being fixed; default ON for normal dev work.
+  option(ENABLE_LINTING "Run ament_* linter tests" ON)
+
+  if(ENABLE_LINTING)
+    find_package(ament_lint_auto REQUIRED)
+    ament_lint_auto_find_test_dependencies()
+  endif()
+
 endif()
 
 ament_package()


### PR DESCRIPTION
## Summary
- add ENABLE_LINTING option in Advancednavigation package
- disable linting in CI by passing `-D ENABLE_LINTING=OFF` to `colcon build` and `colcon test`

## Testing
- `colcon test -D ENABLE_LINTING=OFF --event-handlers console_direct+` *(fails: `colcon: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683adb0c15908321b8243be6e18a35d0