### PR TITLE
Add deb build step and treat test failures as non-blocking

### DIFF
--- a/.github/workflows/ros2-ci.yml
+++ b/.github/workflows/ros2-ci.yml
@@ -71,6 +71,25 @@ jobs:
           source /opt/ros/humble/setup.bash
           colcon build --symlink-install --cmake-args -DENABLE_LINTING=OFF
 
+      # 7. Package workspace into a Debian file
+      - name: Build Debian package
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python3-bloom fakeroot dpkg-dev
+          bloom-generate rosdebian --ros-distro humble
+          dpkg-buildpackage -aamd64 -us -uc
+
+      - name: Collect Debian artifact
+        run: |
+          mkdir -p debs
+          mv ../*.deb debs/
+
+      - name: Upload Debian artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: debs
+          path: debs/*.deb
+
       # Restore missing ament-cmake-test helpers
       - name: Reinstall test helpers
         run: |
@@ -81,9 +100,19 @@ jobs:
             ros-humble-ament-lint-auto \
             ros-humble-ament-lint-common
           source /opt/ros/humble/setup.bash && env
-      # 7. Run tests and report results
+
+      # 8. Run tests but allow failures
       - name: Colcon test
+        continue-on-error: true
         run: |
           source /opt/ros/humble/setup.bash
           colcon test --event-handlers console_direct+ --cmake-args -DENABLE_LINTING=OFF
-          colcon test-result --verbose
+          colcon test-result --verbose || true
+
+      # 9. Run linters and fail the job on lint issues
+      - name: Run linters
+        run: |
+          source /opt/ros/humble/setup.bash
+          ament_cpplint src
+          ament_uncrustify src
+          ament_flake8 src


### PR DESCRIPTION
## Summary
- modify ROS2 CI workflow to build Debian package before running tests
- upload the generated `.deb` as an artifact
- allow the test step to fail without failing the job
- add a dedicated lint step that still fails the workflow if lint issues occur

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_683ae2d3b7948321a4399644faacda1b