### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/accident_report.md
+++ b/.github/ISSUE_TEMPLATE/accident_report.md
@@ -1,0 +1,22 @@
+---
+name: Accident Report
+about: Document any accidents or safety incidents
+title: "[SAFETY] "
+labels: ["accident", "safety"]
+assignees: ''
+---
+
+## Summary
+Describe the accident or incident.
+
+## Location and Time
+Where and when did it occur?
+
+## Equipment / Tools Involved
+What equipment, vehicles, or tools were part of the event?
+
+## Steps to Reproduce (if applicable)
+If this accident was caused by a repeatable issue, provide the steps.
+
+## Additional Context
+Add any other context, logs, or images about the incident.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,25 @@
+---
+name: Bug Report
+about: Create a report to help us fix a problem
+title: "[BUG] "
+labels: ["bug"]
+assignees: ''
+---
+
+## Describe the bug
+A clear and concise description of what the bug is.
+
+## To Reproduce
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Run '...'
+3. See error
+
+## Expected behavior
+A clear and concise description of what you expected to happen.
+
+## Screenshots or logs
+If applicable, add screenshots or logs to help explain your problem.
+
+## Additional context
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & Support
+    url: https://github.com/tractobots/tractobots/discussions
+    about: Please ask and answer questions here.

--- a/.github/ISSUE_TEMPLATE/improvement_report.md
+++ b/.github/ISSUE_TEMPLATE/improvement_report.md
@@ -1,0 +1,19 @@
+---
+name: Improvement Proposal
+about: Suggest an improvement or new feature for the project
+title: "[IMPROVEMENT] "
+labels: ["enhancement"]
+assignees: ''
+---
+
+## Is your feature request related to a problem?
+A clear and concise description of what the problem is.
+
+## Describe the solution you'd like
+A clear and concise description of what you want to happen.
+
+## Describe alternatives you've considered
+A clear and concise description of any alternative solutions or features you've considered.
+
+## Additional context
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
## Summary
- add accident report template
- add bug report template
- add improvement proposal template
- disable blank issues

## Testing
- `colcon test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683b698346dc8321877819648ecb499d