### PR TITLE
Fix upload-artifact version

### DIFF
--- a/.github/workflows/debian-release.yml
+++ b/.github/workflows/debian-release.yml
@@ -49,7 +49,7 @@ jobs:
           mv ../*.deb debs/
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: debs-${{ matrix.arch }}
           path: debs/*.deb
@@ -61,7 +61,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Download all deb packages
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           pattern: debs-*
           merge-multiple: true

--- a/.github/workflows/ros2-ci.yml
+++ b/.github/workflows/ros2-ci.yml
@@ -85,7 +85,7 @@ jobs:
           mv ../*.deb debs/
 
       - name: Upload Debian artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: debs
           path: debs/*.deb


### PR DESCRIPTION
## Summary
- update `actions/upload-artifact` to v4
- update `actions/download-artifact` to v4

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683b6b46ab688321b8c8272f1cbbb5d3