### PR TITLE
Expand paddock usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,11 @@ ros2 run iso_bus_watchdog iso_bus_watchdog_node
 
 ## 🚀 Usage
 
+If you want a short reference with the basic build and run steps,
+see [docs/USAGE_GUIDE.md](docs/USAGE_GUIDE.md).
+When you roll into the paddock, follow the **Example Paddock Workflow**
+section in that guide for a quick start.
+
 Open **five** terminals, each sourcing your workspace:
 
 ```bash

--- a/docs/USAGE_GUIDE.md
+++ b/docs/USAGE_GUIDE.md
@@ -1,0 +1,91 @@
+# Tractobots Usage Guide
+
+This short guide summarizes the typical steps to build and run the Tractobots stack. It is intended as a quick reference for new users.
+
+## 1. Install Dependencies
+
+Tractobots requires **Ubuntu 22.04** with ROS 2 Humble. The repository includes a helper script that installs all required packages:
+
+```bash
+./install_ros2_humble.sh
+```
+
+After installation, remember to source the ROS environment:
+
+```bash
+source /opt/ros/humble/setup.bash
+```
+
+## 2. Clone and Build
+
+Create a workspace, clone the repository, and build with `colcon`:
+
+```bash
+mkdir -p ~/ros2_tractobots/src
+cd ~/ros2_tractobots/src
+git clone <this repository>
+cd ..
+colcon build --symlink-install
+source install/setup.bash
+```
+
+## 3. Launch the Stack
+
+Most launch files live in `src/tractobots_launchers/launch`. To start the sensors and state estimation stack run:
+
+```bash
+ros2 launch tractobots_launchers bringup.launch.py
+```
+
+In separate terminals start the joystick tele‑op driver:
+
+```bash
+ros2 run joy joy_node
+ros2 run tractobots_navigation driver
+```
+
+Optional launch files for MapViz visualization and pose transforms are also available:
+
+```bash
+ros2 launch tractobots_launchers mapviz.launch.py
+ros2 launch tractobots_launchers pose_tf.launch.py
+```
+
+## 4. Additional Nodes
+
+Other packages provide ISOBUS monitoring, mission control UIs, and navigation helpers. Refer to the main [README](../README.md) for detailed usage instructions.
+
+## 5. Example Paddock Workflow
+
+Once you arrive at the paddock with the tractor powered on, open a few
+terminals and source your workspace in each one:
+
+```bash
+source ~/ros2_tractobots/install/setup.bash
+```
+
+Start the sensors and state estimation stack:
+
+```bash
+ros2 launch tractobots_launchers bringup.launch.py
+```
+
+In another terminal run the joystick and driver nodes:
+
+```bash
+ros2 run joy joy_node
+ros2 run tractobots_navigation driver
+```
+
+Drive to the start of your first row and hold **Nav + Y** to record the
+A–B line. Keep **Nav** pressed and hit **Start** to engage row-by-row
+guidance. You can also launch MapViz or the mission control UI for
+visual feedback or mission management:
+
+```bash
+ros2 launch tractobots_launchers mapviz.launch.py
+ros2 run tractobots_mission_ui mission_gui_node
+```
+
+Stop the nodes with **Ctrl+C** when finished.
+


### PR DESCRIPTION
## Summary
- mention paddock workflow in the README
- describe an example paddock workflow in `docs/USAGE_GUIDE.md`

## Testing
- `colcon test` *(fails: `colcon: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683b724cbbd883219062cc84e5418e8a