### PR TITLE
Fix apt package names in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,8 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y \
-          python3-ament-cmake \
-          python3-ament-cmake-test   # ← supplies “ament_cmake_test”
+          ros-humble-ament-cmake \
+          ros-humble-ament-cmake-test   # ← supplies “ament_cmake_test”
 
     # ------------------------------------------------------------
     #  (B)  Neutralise Bloom’s pinned rosdistro index variable


### PR DESCRIPTION
## Summary
- ensure CI installs `ros-humble-ament-cmake` packages instead of generic ones

## Testing
- `colcon test` *(fails: `colcon: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683b8fac2a00832199823197dab8c447