### PR TITLE
Fix rosdep issues for python packages

### DIFF
--- a/docs/NODE_REFERENCES.md
+++ b/docs/NODE_REFERENCES.md
@@ -26,5 +26,5 @@ Sourcing `install/setup.bash` after the build makes all nodes available.
 | `gps_parser`, `imu_publisher`, `pose_transformer` | `src/tractobots_robot_localization/tractobots_robot_localization` | Helper nodes for robot localization. |
 | `mission_ui_node`, `mission_gui_node` | `src/tractobots_mission_ui/tractobots_mission_ui` | Web and Tk GUI interfaces for mission control. |
 
-All packages use standard `ament_cmake` or `ament_python` build tooling and do not require any private dependencies. After running `colcon build` you can launch individual nodes with `ros2 run <package> <executable>`.
+All packages use standard `ament_cmake` build tooling (with `ament_cmake_python` for Python nodes) and do not require any private dependencies. After running `colcon build` you can launch individual nodes with `ros2 run <package> <executable>`.
 

--- a/src/tractobots_bringup/package.xml
+++ b/src/tractobots_bringup/package.xml
@@ -7,7 +7,8 @@
   <maintainer email="nckbass218@gmail.com">Nicholas Bass</maintainer>
   <license>GPLv3</license>
 
-  <buildtool_depend>ament_python</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_python</buildtool_depend>
 
   <exec_depend>launch</exec_depend>
   <exec_depend>launch_ros</exec_depend>
@@ -16,6 +17,6 @@
   <exec_depend>iso_bus_watchdog</exec_depend>
 
   <export>
-    <build_type>ament_python</build_type>
+    <build_type>ament_cmake</build_type>
   </export>
 </package>

--- a/src/tractobots_gps/package.xml
+++ b/src/tractobots_gps/package.xml
@@ -9,8 +9,9 @@
   <maintainer email="nckbass218@gmail.com">Nicholas Bass</maintainer>
   <license>GPLv3</license>
 
-  <!-- Use ament_python since this is a Python-based node -->
-  <buildtool_depend>ament_python</buildtool_depend>
+  <!-- Python-based node built with ament_cmake -->
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_python</buildtool_depend>
 
   <!-- Runtime dependencies -->
   <exec_depend>rclpy</exec_depend>
@@ -21,6 +22,6 @@
   <test_depend>ament_lint_common</test_depend>
 
   <export>
-    <build_type>ament_python</build_type>
+    <build_type>ament_cmake</build_type>
   </export>
 </package>

--- a/src/tractobots_launchers/package.xml
+++ b/src/tractobots_launchers/package.xml
@@ -7,8 +7,9 @@
   <maintainer email="nckbass218@gmail.com">Nicholas Bass</maintainer>
   <license>GPLv3</license>
 
-  <!-- This is a pure‑launch package, so only ament_python is needed -->
-  <buildtool_depend>ament_python</buildtool_depend>
+  <!-- Pure launch package built with ament_cmake -->
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_python</buildtool_depend>
 
   <!-- Launch files use these packages -->
   <exec_depend>launch</exec_depend>
@@ -21,6 +22,6 @@
   <exec_depend>mapviz</exec_depend>
 
   <export>
-    <build_type>ament_python</build_type>
+    <build_type>ament_cmake</build_type>
   </export>
 </package>

--- a/src/tractobots_mission_ui/package.xml
+++ b/src/tractobots_mission_ui/package.xml
@@ -6,7 +6,8 @@
   <maintainer email="nckbass218@gmail.com">Nicholas Bass</maintainer>
   <license>GPLv3</license>
 
-  <buildtool_depend>ament_python</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_python</buildtool_depend>
 
   <exec_depend>rclpy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
@@ -15,6 +16,6 @@
   <test_depend>ament_lint_common</test_depend>
 
   <export>
-    <build_type>ament_python</build_type>
+    <build_type>ament_cmake</build_type>
   </export>
 </package>

--- a/src/tractobots_nav2/package.xml
+++ b/src/tractobots_nav2/package.xml
@@ -7,13 +7,14 @@
   <maintainer email="nckbass218@gmail.com">Nicholas Bass</maintainer>
   <license>GPLv3</license>
 
-  <buildtool_depend>ament_python</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_python</buildtool_depend>
 
   <exec_depend>launch</exec_depend>
   <exec_depend>launch_ros</exec_depend>
   <exec_depend>nav2_bringup</exec_depend>
 
   <export>
-    <build_type>ament_python</build_type>
+    <build_type>ament_cmake</build_type>
   </export>
 </package>

--- a/src/tractobots_navigation/package.xml
+++ b/src/tractobots_navigation/package.xml
@@ -7,7 +7,8 @@
   <maintainer email="nckbass218@gmail.com">Nicholas Bass</maintainer>
   <license>GPLv3</license>
 
-  <buildtool_depend>ament_python</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_python</buildtool_depend>
 
   <!-- Runtime deps -->
   <exec_depend>rclpy</exec_depend>
@@ -22,6 +23,6 @@
   <test_depend>ament_lint_common</test_depend>
 
   <export>
-    <build_type>ament_python</build_type>
+    <build_type>ament_cmake</build_type>
   </export>
 </package>

--- a/src/tractobots_robot_localization/package.xml
+++ b/src/tractobots_robot_localization/package.xml
@@ -11,7 +11,8 @@
   <license>GPLv3</license>
 
   <!-- Build system -->
-  <buildtool_depend>ament_python</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_python</buildtool_depend>
 
   <!-- Runtime code + messages -->
   <exec_depend>rclpy</exec_depend>
@@ -30,6 +31,6 @@
   <test_depend>ament_lint_common</test_depend>
 
   <export>
-    <build_type>ament_python</build_type>
+    <build_type>ament_cmake</build_type>
   </export>
 </package>


### PR DESCRIPTION
## Summary
- convert python packages to use `ament_cmake` build type
- update docs to mention `ament_cmake_python`

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683b9946ecd88321a0db51a69c81cc03