### PR TITLE
Fix ROS2 CI environment

### DIFF
--- a/.github/workflows/ros2-ci.yml
+++ b/.github/workflows/ros2-ci.yml
@@ -16,20 +16,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      # 2. Install ROS 2 (Humble)
-      - name: Setup ROS 2
-        run: |
-          sudo apt update && sudo apt install -y curl gnupg2 lsb-release software-properties-common
-          sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
-          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/ros2.list
-          sudo apt update
-          sudo apt install -y ros-humble-desktop python3-colcon-common-extensions python3-rosdep2 python3-pip
-
-      - name: Install ROS 2 base
-        run: |
-          sudo apt update
-          sudo apt install ros-humble-ros-base -y
-          source /opt/ros/humble/setup.bash
+      # 2. Install ROS 2 Humble using the official action
+      - name: Set up ROS 2 Humble
+        uses: ros-tooling/setup-ros@v0.4
+        with:
+          required-ros-distributions: humble
 
       # 3. Install OS-level build tools
       - name: Install OS dependencies
@@ -51,19 +42,18 @@ jobs:
           source /opt/ros/humble/setup.bash
           echo "PYTHONPATH=$PYTHONPATH"
 
-      # 4. Install ROS 2 package dependencies
+      # 4. Enable required apt repositories for dependencies
+      - name: Enable universe repo (needed for libunwind-dev, glog, Nav2)
+        run: |
+          sudo add-apt-repository -y universe
+          sudo apt-get update
+
+      # 5. Install ROS 2 package dependencies
       - name: rosdep install
         run: |
           sudo rosdep init || true
           rosdep update
-          rosdep install --from-paths src --ignore-src -r -y
-
-      # 5. Prepare build environment
-      - name: Install ros-base and setup
-        run: |
-          sudo apt update
-          sudo apt install -y ros-humble-ros-base
-          source /opt/ros/humble/setup.bash
+          rosdep install --from-paths src --ignore-src -y --rosdistro humble --skip-keys "agisostack_plus_plus"
 
       # 6. Build the workspace
       - name: Colcon build

--- a/src/tractobots_description/CMakeLists.txt
+++ b/src/tractobots_description/CMakeLists.txt
@@ -2,7 +2,13 @@ cmake_minimum_required(VERSION 3.22)
 project(tractobots_description LANGUAGES CXX)
 
 find_package(ament_cmake REQUIRED)
- # ★ Codex-edit
+
+option(ENABLE_LINTING "Run ament linters" ON)
+
+if(ENABLE_LINTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
 
 install(DIRECTORY urdf meshes launch rviz
   DESTINATION share/${PROJECT_NAME})


### PR DESCRIPTION
## Summary
- install ROS 2 using `ros-tooling/setup-ros`
- enable Ubuntu universe repo before rosdep
- skip the agisostack dependency in CI
- make ENABLE_LINTING option functional in `tractobots_description`

## Testing
- `colcon list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683bbad582e883219c818050888156ff