### PR TITLE
Add explicit Nav2 apt deps

### DIFF
--- a/.github/workflows/ros2-ci.yml
+++ b/.github/workflows/ros2-ci.yml
@@ -48,6 +48,11 @@ jobs:
           sudo add-apt-repository -y universe
           sudo apt-get update
 
+      # Extra dependencies for Nav2 bringup which require universe packages
+      - name: Install Nav2 dependencies
+        run: |
+          sudo apt-get install -y libunwind-dev libgoogle-glog-dev || true
+
       # 5. Install ROS 2 package dependencies
       - name: rosdep install
         run: |


### PR DESCRIPTION
## Summary
- install nav2 packages' apt prerequisites before running rosdep

## Testing
- `git status -s`

------
https://chatgpt.com/codex/tasks/task_e_683bc21bab1c832185b38f0dc3add1c1