### PR TITLE
Enable universe repo for missing dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,10 @@ export DISPLAY=:0
 > **Note**
 > Tractobots currently targets **Ubuntu 22.04 (Jammy)**. Running the
 > installation steps on Ubuntu 24.04 (Noble) may cause `rosdep` to fail with
-> missing packages such as `libunwind-dev`. For best results use a Jammy-based
-> system or build ROS 2 and Nav2 from source on your distribution.
+> missing packages such as `libunwind-dev`. Ensure the **universe** repository is
+> enabled (`sudo add-apt-repository -y universe`) if apt cannot locate these
+> packages. For best results use a Jammy-based system or build ROS 2 and Nav2
+> from source on your distribution.
 
 ```bash
 sudo apt update && sudo apt install -y   curl gnupg2 lsb-release software-properties-common

--- a/docs/CODEX_GUIDE.md
+++ b/docs/CODEX_GUIDE.md
@@ -12,6 +12,14 @@ up all required packages is to run the helper script in the repository root:
 ./install_ros2_humble.sh
 ```
 
+If apt cannot locate packages such as `libunwind-dev`, make sure the
+`universe` repository is enabled:
+
+```bash
+sudo add-apt-repository -y universe
+sudo apt update
+```
+
 It installs ROS 2, Python build tools, and initializes `rosdep`. Make sure to
 `source /opt/ros/humble/setup.bash` after installation.
 

--- a/docs/USAGE_GUIDE.md
+++ b/docs/USAGE_GUIDE.md
@@ -10,6 +10,14 @@ Tractobots requires **Ubuntu 22.04** with ROS 2 Humble. The repository include
 ./install_ros2_humble.sh
 ```
 
+If apt cannot find packages like `libunwind-dev`, enable the `universe`
+repository first:
+
+```bash
+sudo add-apt-repository -y universe
+sudo apt update
+```
+
 After installation, remember to source the ROS environment:
 
 ```bash

--- a/install_ros2_humble.sh
+++ b/install_ros2_humble.sh
@@ -13,6 +13,9 @@ fi
 sudo apt update && sudo apt install -y \
   curl gnupg2 lsb-release software-properties-common
 
+# Enable the 'universe' repository for packages like libunwind-dev
+sudo add-apt-repository -y universe
+
 # Add the ROS 2 repository and key
 sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key \
   -o /usr/share/keyrings/ros-archive-keyring.gpg


### PR DESCRIPTION
## Summary
- enable `universe` repo in `install_ros2_humble.sh`
- document adding the repo in README and usage docs
- mention `universe` repo for Codex users

## Testing
- `colcon test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683bd3c0b9d083218ba5f4162b8690a6