### PR TITLE
Fix rosdep in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,11 +54,25 @@ jobs:
     #  (B)  Neutralise Bloom’s pinned rosdistro index variable
     #       (it appears once python3-bloom is on the system).
     # ------------------------------------------------------------
-    - name: Prevent Bloom from breaking rosdep
-      shell: bash
-      run: |
-        unset ROSDISTRO_INDEX_URL || true
-        unset ROS_DISTRO_INDEX_URL || true
+      - name: Prevent Bloom from breaking rosdep
+        shell: bash
+        run: |
+          unset ROSDISTRO_INDEX_URL || true
+          unset ROS_DISTRO_INDEX_URL || true
+
+      # ------------------------------------------------------------
+      #  Enable Ubuntu "universe" repo so rosdep can install
+      #  packages like libunwind-dev required by Nav2
+      # ------------------------------------------------------------
+      - name: Enable universe repo
+        run: |
+          sudo add-apt-repository -y universe
+          sudo apt-get update
+
+      # Extra dependencies for Nav2 bringup which require universe packages
+      - name: Install Nav2 dependencies
+        run: |
+          sudo apt-get install -y libunwind-dev libgoogle-glog-dev || true
 
     # ------------------------------------------------------------
     #  (C)  Install runtime build dependencies for the workspace


### PR DESCRIPTION
## Summary
- add universe repo step so rosdep can install Nav2 dependencies

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683bdb5f41a48321a962edb8fc4613ea