### PR TITLE
Fix em/empy conflict in ROS setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,11 @@ sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key   
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg]   http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main"   | sudo tee /etc/apt/sources.list.d/ros2.list
 
 sudo apt update
-sudo apt install -y ros-humble-desktop   python3-colcon-common-extensions python3-rosdep2 python3-pip
+sudo apt install -y ros-humble-desktop   python3-colcon-common-extensions \
+  python3-rosdep2 python3-empy python3-pip
+
+# Remove any conflicting 'em' package if present
+pip3 uninstall -y em 2>/dev/null || true
 ```
 
 You can also run the provided helper script for a non-interactive setup:

--- a/install_ros2_humble.sh
+++ b/install_ros2_humble.sh
@@ -29,7 +29,11 @@ sudo apt install -y \
   ros-humble-desktop \
   python3-colcon-common-extensions \
   python3-rosdep2 \
+  python3-empy \
   python3-pip
+
+# Remove conflicting 'em' package if present
+pip3 uninstall -y em 2>/dev/null || true
 
 # Initialize rosdep if needed
 if ! rosdep --version >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- ensure `python3-empy` is installed in ROS Humble setup
- uninstall conflicting `em` package automatically
- document the workaround in README

## Testing
- `bash -n install_ros2_humble.sh`


------
https://chatgpt.com/codex/tasks/task_e_683be54eafcc832182ae4468a42e814d