### PR TITLE
Fix CI apt repository issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,15 @@ jobs:
         unset ROS_DISTRO_INDEX_URL || true
 
     # ------------------------------------------------------------
+    #  Ensure the 'universe' repository is available so rosdep can
+    #  install packages like libunwind-dev and libgoogle-glog-dev
+    # ------------------------------------------------------------
+    - name: Enable universe repo
+      run: |
+        sudo add-apt-repository -y universe
+        sudo apt-get update
+
+    # ------------------------------------------------------------
     #  (C)  Install runtime build dependencies for the workspace
     # ------------------------------------------------------------
     - name: rosdep install


### PR DESCRIPTION
## Summary
- update GitHub Action to enable the Ubuntu *universe* repository before running rosdep

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_683be79aa7c88321aacf2710141e9f8c