### PR TITLE
Fix ros2 install script for missing dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,18 @@ export DISPLAY=:0
 ```bash
 sudo apt update && sudo apt install -y   curl gnupg2 lsb-release software-properties-common
 
+# Enable the universe repo for packages like libunwind-dev
+sudo add-apt-repository -y universe
+sudo apt update
+
 # Add ROS 2 repos & keys
 sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key   -o /usr/share/keyrings/ros-archive-keyring.gpg
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg]   http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main"   | sudo tee /etc/apt/sources.list.d/ros2.list
 
 sudo apt update
 sudo apt install -y ros-humble-desktop   python3-colcon-common-extensions \
-  python3-rosdep2 python3-empy python3-pip
+  python3-rosdep2 python3-empy python3-pip \
+  libunwind-dev libgoogle-glog-dev
 
 # Remove any conflicting 'em' package if present
 pip3 uninstall -y em 2>/dev/null || true

--- a/install_ros2_humble.sh
+++ b/install_ros2_humble.sh
@@ -15,6 +15,7 @@ sudo apt update && sudo apt install -y \
 
 # Enable the 'universe' repository for packages like libunwind-dev
 sudo add-apt-repository -y universe
+sudo apt update
 
 # Add the ROS 2 repository and key
 sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key \
@@ -30,7 +31,9 @@ sudo apt install -y \
   python3-colcon-common-extensions \
   python3-rosdep2 \
   python3-empy \
-  python3-pip
+  python3-pip \
+  libunwind-dev \
+  libgoogle-glog-dev
 
 # Remove conflicting 'em' package if present
 pip3 uninstall -y em 2>/dev/null || true


### PR DESCRIPTION
## Summary
- enable `universe` repo and update before installing ROS2 packages
- install `libunwind-dev` and `libgoogle-glog-dev`
- document the extra step in the README

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_683bf4ecae5483219936d04a60b890f0