### PR TITLE
Add build helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,12 @@ next section to launch the stack.
     source install/setup.bash
     ```
 
+    Or simply run the convenience script from this repository:
+
+    ```bash
+    ./build_workspace.sh
+    ```
+
 ---
 
 ## 🛠️ Detailed Build & Run
@@ -187,6 +193,12 @@ cd ~/ros2_tractobots
 rosdep install --from-paths src --ignore-src -r -y
 colcon build --symlink-install
 source install/setup.bash
+```
+
+Alternatively run the helper script from the repository root:
+
+```bash
+./build_workspace.sh
 ```
 
 ### 2. Running a simulation

--- a/build_workspace.sh
+++ b/build_workspace.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Simple helper to build the Tractobots workspace.
+# Usage: ./build_workspace.sh [<workspace_dir>]
+# Default workspace directory is ~/ros2_tractobots
+
+set -e
+
+WS_DIR="${1:-$HOME/ros2_tractobots}"
+REPO_ROOT="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+
+mkdir -p "$WS_DIR/src"
+
+# Symlink this repository into the workspace if not already present
+if [ ! -e "$WS_DIR/src/tractobots" ]; then
+    ln -s "$REPO_ROOT" "$WS_DIR/src/tractobots"
+fi
+
+cd "$WS_DIR"
+
+if ! command -v colcon >/dev/null 2>&1; then
+    echo "colcon not found. Please install ROS 2 Humble before running this script." >&2
+    exit 1
+fi
+
+# Install package dependencies
+rosdep install --from-paths src --ignore-src -r -y
+
+# Build the workspace
+colcon build --symlink-install
+
+echo "\nBuild complete. Source the workspace with:\n  source \"$WS_DIR/install/setup.bash\""


### PR DESCRIPTION
## Summary
- add a `build_workspace.sh` helper for colcon builds
- document the script in the README

## Testing
- `colcon test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683e61afe01483219dc2037dd287299b