### PR TITLE
Fix apt error in CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     # ------------------------------------------------------------
     #  Source ROS 2 Humble toolchain
     # ------------------------------------------------------------
-    - uses: ros-tooling/setup-ros@0.7.1
+    - uses: ros-tooling/setup-ros@v0.7.12
       with:
         required-ros-distributions: humble
 

--- a/.github/workflows/debian-release.yml
+++ b/.github/workflows/debian-release.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup ROS 2
-        uses: ros-tooling/setup-ros@v0.7
+        uses: ros-tooling/setup-ros@v0.7.12
         with:
           required-ros-distributions: ${{ env.ROS_DISTRO }}
 

--- a/.github/workflows/ros2-ci.yml
+++ b/.github/workflows/ros2-ci.yml
@@ -18,7 +18,7 @@ jobs:
 
       # 2. Install ROS 2 Humble using the official action
       - name: Set up ROS 2 Humble
-        uses: ros-tooling/setup-ros@v0.4
+        uses: ros-tooling/setup-ros@v0.7.12
         with:
           required-ros-distributions: humble
 


### PR DESCRIPTION
## Summary
- use latest ros-tooling/setup-ros version (v0.7.12)

## Testing
- `colcon` not found, so no tests were run


------
https://chatgpt.com/codex/tasks/task_e_683e69d226888321a391363f4d08569a