### PR TITLE
Vendor setup-ros action

### DIFF
--- a/.github/actions/setup-ros/action.yml
+++ b/.github/actions/setup-ros/action.yml
@@ -1,0 +1,7 @@
+name: Setup ROS 2
+runs:
+  using: composite
+  steps:
+    - name: Install ROS 2 Humble
+      run: bash "$GITHUB_ACTION_PATH/install_ros2_humble.sh"
+      shell: bash

--- a/.github/actions/setup-ros/install_ros2_humble.sh
+++ b/.github/actions/setup-ros/install_ros2_humble.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -e
+
+# ROS 2 Humble is officially supported on Ubuntu 22.04 (Jammy)
+OS_CODENAME=$(lsb_release -cs)
+if [[ "$OS_CODENAME" != "jammy" ]]; then
+  echo "ROS 2 Humble packages are only available for Ubuntu 22.04 (Jammy)." >&2
+  echo "Detected codename: $OS_CODENAME" >&2
+  echo "Consider using a Jammy-based system or building ROS 2 from source on this OS." >&2
+  exit 1
+fi
+
+sudo apt update && sudo apt install -y \
+  curl gnupg2 lsb-release software-properties-common
+
+# Enable the 'universe' repository for packages like libunwind-dev
+sudo add-apt-repository -y universe
+sudo apt update
+
+# Add the ROS 2 repository and key
+sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key \
+  -o /usr/share/keyrings/ros-archive-keyring.gpg
+
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] \
+  http://packages.ros.org/ros2/ubuntu $OS_CODENAME main" | \
+  sudo tee /etc/apt/sources.list.d/ros2.list
+
+sudo apt update
+sudo apt install -y \
+  ros-humble-desktop \
+  python3-colcon-common-extensions \
+  python3-rosdep2 \
+  python3-empy \
+  python3-pip \
+  libunwind-dev \
+  libgoogle-glog-dev
+
+# Remove conflicting 'em' package if present
+pip3 uninstall -y em 2>/dev/null || true
+
+# Initialize rosdep if needed
+if ! rosdep --version >/dev/null 2>&1; then
+  echo "rosdep not found; ensure python3-rosdep2 installed correctly" >&2
+fi
+sudo rosdep init || true
+rosdep update
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,7 @@ jobs:
     # ------------------------------------------------------------
     #  Source ROS 2 Humble toolchain
     # ------------------------------------------------------------
-    - uses: ros-tooling/setup-ros@v0.7.12
-      with:
-        required-ros-distributions: humble
+    - uses: ./.github/actions/setup-ros
 
     # ------------------------------------------------------------
     #  (A)  Install ONLY what unit-tests need

--- a/.github/workflows/debian-release.yml
+++ b/.github/workflows/debian-release.yml
@@ -20,9 +20,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup ROS 2
-        uses: ros-tooling/setup-ros@v0.7.12
-        with:
-          required-ros-distributions: ${{ env.ROS_DISTRO }}
+        uses: ./.github/actions/setup-ros
 
       - name: Register qemu for ARM64
         if: matrix.arch == 'arm64'

--- a/.github/workflows/ros2-ci.yml
+++ b/.github/workflows/ros2-ci.yml
@@ -18,9 +18,7 @@ jobs:
 
       # 2. Install ROS 2 Humble using the official action
       - name: Set up ROS 2 Humble
-        uses: ros-tooling/setup-ros@v0.7.12
-        with:
-          required-ros-distributions: humble
+        uses: ./.github/actions/setup-ros
 
       # 3. Install OS-level build tools
       - name: Install OS dependencies


### PR DESCRIPTION
## Summary
- vendor a simple `setup-ros` action that calls `install_ros2_humble.sh`
- use the vendored action in CI workflows

## Testing
- `bash -n .github/actions/setup-ros/install_ros2_humble.sh`

------
https://chatgpt.com/codex/tasks/task_e_683e75b60da88321aaed28b63f4e89e4