### PR TITLE
Fix ROS setup action export

### DIFF
--- a/.github/actions/setup-ros/action.yml
+++ b/.github/actions/setup-ros/action.yml
@@ -5,3 +5,7 @@ runs:
     - name: Install ROS 2 Humble
       run: bash "$GITHUB_ACTION_PATH/install_ros2_humble.sh"
       shell: bash
+    - name: Source ROS 2 setup script
+      # Persist sourcing of ROS environment for subsequent steps
+      run: echo "BASH_ENV=/opt/ros/humble/setup.bash" >> "$GITHUB_ENV"
+      shell: bash

--- a/README.md
+++ b/README.md
@@ -358,15 +358,15 @@ A CI workflow (`.github/workflows/ros2-ci.yml`) now also builds & lint‑tests:
 - `iso_bus_watchdog` alongside the other packages
 - SocketCAN integration checks on Ubuntu 22.04 & Humble
 - CI runner explicitly uses `ubuntu-22.04` so ROS 2 packages install correctly
-- Uses `ros-tooling/setup-ros@v0.7.12` so `apt-get update` works with the current ROS key
+- Uses the vendored `.github/actions/setup-ros` action so `apt-get update` works with the current ROS key
+- The action sets `BASH_ENV` so the ROS environment is sourced for all subsequent steps
 
 Example step:
 
 ```yaml
 - name: Setup ROS 2
-  uses: ros-tooling/setup-ros@v0.7.12
-  with:
-    required-ros-distributions: humble
+  uses: ./.github/actions/setup-ros
+  # No additional inputs required
 ```
 
 ## 🤖 Codex Quickstart


### PR DESCRIPTION
## Summary
- fix setup-ros action to set BASH_ENV so the ROS environment is sourced
- document the BASH_ENV behavior in the README

## Testing
- `echo no tests`


------
https://chatgpt.com/codex/tasks/task_e_683e8469d6248321a0c5d8775307c9ec