### PR TITLE
Improve build script logging

### DIFF
--- a/build_workspace.sh
+++ b/build_workspace.sh
@@ -4,6 +4,7 @@
 # Default workspace directory is ~/ros2_tractobots
 
 set -e
+set -o pipefail  # ensure failure inside pipelines is caught
 
 WS_DIR="${1:-$HOME/ros2_tractobots}"
 REPO_ROOT="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
@@ -26,6 +27,14 @@ fi
 rosdep install --from-paths src --ignore-src -r -y
 
 # Build the workspace
-colcon build --symlink-install
+colcon build --symlink-install \
+  --event-handlers console_cohesion+ --event-handlers console_direct+ \
+  2>&1 | tee build.log
+BUILD_STATUS=${PIPESTATUS[0]}
+
+if [ $BUILD_STATUS -ne 0 ]; then
+  echo "\nBuild failed. See build.log for details." >&2
+  exit $BUILD_STATUS
+fi
 
 echo "\nBuild complete. Source the workspace with:\n  source \"$WS_DIR/install/setup.bash\""


### PR DESCRIPTION
## Summary
- show colcon build output using console event handlers
- tee build.log and fail build if colcon returns non-zero

## Testing
- `bash -n build_workspace.sh`

------
https://chatgpt.com/codex/tasks/task_e_683eb9a093f483219457b934e489dfdf