### PR TITLE
Fix Python package installation path

### DIFF
--- a/src/tractobots_robot_localization/CMakeLists.txt
+++ b/src/tractobots_robot_localization/CMakeLists.txt
@@ -5,7 +5,11 @@ find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_python REQUIRED)
 find_package(rclpy REQUIRED)
 
-ament_python_install_package(${PROJECT_NAME})
+# Install the python package located in the 'src' directory
+ament_python_install_package(
+  ${PROJECT_NAME}
+  PACKAGE_DIR src
+)
 
 install(
   DIRECTORY launch params


### PR DESCRIPTION
## Summary
- fix install path for `tractobots_robot_localization` python package

## Testing
- `colcon --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841352729f08321bb8ba2c39fea0b1e