### PR TITLE
Add Discord link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,7 +468,8 @@ cp scripts/autostart.sh /etc/init.d/
 
 ### Getting Help
 - **📋 GitHub Issues**: Bug reports and feature requests
-- **💬 Discussions**: Community Q&A and project discussions  
+- **💬 Discussions**: Community Q&A and project discussions
+- **🌐 Discord**: [Join our community](https://discord.gg/wN2F3uFF) for real-time chat and support
 - **📧 Email Support**: nicholasbass@crop-crusaders.com (security issues)
 - **📚 Documentation**: Comprehensive guides in `/docs` directory
 


### PR DESCRIPTION
## Summary
- mention Crop Crusaders Discord server in README

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686aea54182c83218c52ed6adb01a50e